### PR TITLE
feat: add scan segment env vars as CF stack parameters

### DIFF
--- a/api/cron/delete/package.json
+++ b/api/cron/delete/package.json
@@ -20,7 +20,7 @@
 			],
 			"name": "Leo_Botmon_api_cron_delete",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"build": {}
 		}

--- a/api/cron/get/package.json
+++ b/api/cron/get/package.json
@@ -21,7 +21,7 @@
 			],
 			"name": "Leo_Botmon_api_cron_get",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"build": {}
 		}

--- a/api/cron/save/package.json
+++ b/api/cron/save/package.json
@@ -20,7 +20,7 @@
 			],
 			"name": "Leo_Botmon_api_cron_save",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"build": {}
 		}

--- a/api/cron/saveOverrides/package.json
+++ b/api/cron/saveOverrides/package.json
@@ -17,7 +17,7 @@
 			],
 			"name": "Leo_Botmon_api_setting_saveOverrides",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"build": {}
 		}

--- a/api/eventSettings/get/package.json
+++ b/api/eventSettings/get/package.json
@@ -20,7 +20,7 @@
 			],
 			"name": "Leo_Botmon_api_event_settings_get",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"build": {}
 		}

--- a/api/eventSettings/save/package.json
+++ b/api/eventSettings/save/package.json
@@ -20,7 +20,7 @@
 			],
 			"name": "Leo_Botmon_api_event_settings_save",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"build": {}
 		}

--- a/api/logs/package.json
+++ b/api/logs/package.json
@@ -16,7 +16,7 @@
 			"name": "Leo_Botmon_api_logs",
 			"handler": "handler",
 			"role": null,
-			"memory": 256,
+			"memory": 512,
 			"timeout": 30,
 			"env": {
 				"Resources": {

--- a/api/settings/package.json
+++ b/api/settings/package.json
@@ -18,7 +18,7 @@
 			],
 			"name": "Leo_Botmon_api_settings",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"env": {
 				"Resources": {

--- a/api/sns/package.json
+++ b/api/sns/package.json
@@ -18,7 +18,7 @@
 			],
 			"name": "Leo_Botmon_api_sns",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 30,
 			"build": {},
 			"env": {

--- a/api/stats/package.json
+++ b/api/stats/package.json
@@ -21,7 +21,9 @@
 			"env": {
 				"Resources": {
 					"LeoStats": "${LeoStats}"
-				}
+				},
+				"BOT_SCAN_SEGMENTS": "${BotScanSegments}",
+				"QUEUE_SCAN_SEGMENTS": "${QueueScanSegments}"
 			},
 			"build": {
 				"include": [

--- a/api/stats/package.json
+++ b/api/stats/package.json
@@ -17,7 +17,7 @@
 			"handler": "handler",
 			"role": null,
 			"memory": 1024,
-			"timeout": 10,
+			"timeout": 30,
 			"env": {
 				"Resources": {
 					"LeoStats": "${LeoStats}"

--- a/api/system/get/package.json
+++ b/api/system/get/package.json
@@ -16,7 +16,7 @@
 			"name": "Leo_Botmon_api_system_get",
 			"handler": "handler",
 			"role": null,
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10
 		}
 	},

--- a/api/system/save/package.json
+++ b/api/system/save/package.json
@@ -19,7 +19,7 @@
 			"name": "Leo_Botmon_api_system_save",
 			"handler": "handler",
 			"role": null,
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10
 		}
 	},

--- a/bots/healthSNS/package.json
+++ b/bots/healthSNS/package.json
@@ -18,7 +18,7 @@
 					"ref": "core.roles.LeoHealthCheckRole"
 				}
 			},
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"cron": {
 				"owner": "leo",

--- a/bots/healthSNS/package.json
+++ b/bots/healthSNS/package.json
@@ -30,7 +30,9 @@
 					"SnsTopic": "${HealthCheckSNS}",
 					"DomainUrl": "https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/Release",
 					"LeoStats": "${LeoStats}"
-				}
+				},
+				"BOT_SCAN_SEGMENTS": "${BotScanSegments}",
+				"QUEUE_SCAN_SEGMENTS": "${QueueScanSegments}"
 			},
 			"build": {
 				"include": [

--- a/changelogs/v3.0.7_changelog.md
+++ b/changelogs/v3.0.7_changelog.md
@@ -42,6 +42,11 @@ Values had been corrected manually in AWS; this release sets **`config.leo.memor
 
 See Jira [ES-2958](https://chb.atlassian.net/browse/ES-2958) for the full investigation.
 
+### StatsApi Lambda timeout (`api/stats`)
+
+- **`config.leo.timeout` increased from 10s to 30s** so CloudFormation matches the manually adjusted **ProdStreamBotmon-StatsApi** configuration and is not reverted to 10s on deploy.
+- **Memory** remains **1024 MB** in `package.json`. **ProdStream** currently runs **1232 MB** (manual drift). After this release, monitor memory use (especially Stream); **`memory` will most likely need to be raised** (e.g. toward **1232 MB**) in a follow-up change so the next stack update does not drop Stream back to 1024 MB.
+
 ---
 
 Jira: [ES-2966](https://chb.atlassian.net/browse/ES-2966) (scan segment parameters; PR [#32](https://github.com/LeoPlatform/bus-ui/pull/32)), [ES-2958](https://chb.atlassian.net/browse/ES-2958) (Lambda memory; same PR / release)

--- a/changelogs/v3.0.7_changelog.md
+++ b/changelogs/v3.0.7_changelog.md
@@ -1,0 +1,31 @@
+# Botmon v3.0.7 Changelog
+
+## Bug Fix
+
+As always if there are questions/issues using Botmon or if you have improvements you would like made reach out to [#h_rstreams](https://chubrox.slack.com/archives/C033LCSFHF0)
+
+### Restore DynamoDB scan segment environment variables
+
+During the v3.0.6 deploy (Node.js 16 to Node.js 20 upgrade), the environment variables `BOT_SCAN_SEGMENTS` and `QUEUE_SCAN_SEGMENTS` were wiped from the StatsApi and healthSNS Lambda functions. These variables control the number of parallel segments used when scanning DynamoDB tables and had been set manually outside of CloudFormation.
+
+When CloudFormation updated the stacks, it replaced the entire `Environment.Variables` block, dropping the manually-configured values. This caused those functions to fall back to the default of 1 segment, reducing scan parallelism on larger buses.
+
+#### What changed
+
+- Added `BotScanSegments` and `QueueScanSegments` as CloudFormation stack parameters with a default of `"1"`
+- Added `BOT_SCAN_SEGMENTS` and `QUEUE_SCAN_SEGMENTS` environment variables to the **StatsApi** and **healthSNS** Lambda function definitions
+- These values are now managed by CloudFormation and will persist across future deploys
+
+#### Deploy notes
+
+When updating each stack, set the new CF parameters as follows:
+
+| Environment | BotScanSegments | QueueScanSegments |
+|---|---|---|
+| ProdStream | 16 | 3 |
+| TestStream | 16 | 3 |
+| All others | 1 (default, no action needed) | 1 (default, no action needed) |
+
+---
+
+Jira: [ES-2966](https://chb.atlassian.net/browse/ES-2966)

--- a/changelogs/v3.0.7_changelog.md
+++ b/changelogs/v3.0.7_changelog.md
@@ -26,6 +26,22 @@ When updating each stack, set the new CF parameters as follows:
 | TestStream | 16 | 3 |
 | All others | 1 (default, no action needed) | 1 (default, no action needed) |
 
+### Restore Lambda memory to 512 MB (affected API handlers)
+
+A March 2026 CloudFormation deploy regenerated templates from `package.json` with **256 MB** for several Botmon Lambdas. In production and test, **CronGetApi** and related handlers were using **~438–440 MB during INIT**, so **256 MB caused `Runtime.OutOfMemory`** and **502** responses from API Gateway.
+
+Values had been corrected manually in AWS; this release sets **`config.leo.memory` to 512** in source for the same twelve functions so the next deploy does not revert them to 256 MB.
+
+#### Functions updated (`package.json` → `config.leo.memory` 256 → 512)
+
+- `api/cron/get`, `save`, `delete`, `saveOverrides`
+- `api/logs`
+- `api/eventSettings/get`, `save`
+- `api/settings`, `api/sns`, `api/system/get`, `save`
+- `bots/healthSNS` (LeoHealthCheck cron)
+
+See Jira [ES-2958](https://chb.atlassian.net/browse/ES-2958) for the full investigation.
+
 ---
 
-Jira: [ES-2966](https://chb.atlassian.net/browse/ES-2966)
+Jira: [ES-2966](https://chb.atlassian.net/browse/ES-2966) (scan segment parameters; PR [#32](https://github.com/LeoPlatform/bus-ui/pull/32)), [ES-2958](https://chb.atlassian.net/browse/ES-2958) (Lambda memory; same PR / release)

--- a/cloudformation/io.js
+++ b/cloudformation/io.js
@@ -13,5 +13,15 @@ module.exports = {
 			"Description": "Custom Javascript for the web app",
 			"Type": "String"
 		},
+		"BotScanSegments": {
+			"Description": "Number of parallel scan segments for the bots (LeoCron) DynamoDB table",
+			"Type": "String",
+			"Default": "1"
+		},
+		"QueueScanSegments": {
+			"Description": "Number of parallel scan segments for the queues (LeoEvent) DynamoDB table",
+			"Type": "String",
+			"Default": "1"
+		},
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "botmon",
-	"version": "3.0.6",
+	"version": "3.0.7",
 	"description": "",
 	"main": "app.js",
 	"engines": {


### PR DESCRIPTION
## Summary
- Added `BotScanSegments` and `QueueScanSegments` as CloudFormation parameters with default value `"1"`
- Added `BOT_SCAN_SEGMENTS` and `QUEUE_SCAN_SEGMENTS` environment variables to **StatsApi** and **healthSNS** Lambda functions
- These are the functions that consume `lib/stats.js` where parallel scan segments are used

## Background
During the early March 2026 Node 20 upgrade deploy, `BOT_SCAN_SEGMENTS` and `QUEUE_SCAN_SEGMENTS` env vars were wiped from Lambda functions. These had been set manually (outside of CloudFormation), so when CF updated the stacks it overwrote the entire `Environment.Variables` block.

This PR codifies these env vars as proper CF stack parameters so they persist across future deploys.

## Deploy Instructions
After merging, when updating each stack, set the new CF parameters:

| Environment | BotScanSegments | QueueScanSegments |
|---|---|---|
| ProdStream | 16 | 3 |
| TestStream | 16 | 3 |
| All others | 1 (default) | 1 (default) |

**Note:** ProdStream StatsApi currently has Clint's manual fix (both set to 20). After deploying with this PR, the values will be controlled by the CF parameters. Set ProdStream to `BotScanSegments=16, QueueScanSegments=3` to match the pre-incident values from `test/process.js`.

## Drift Audit
Checked all 9 Botmon stacks (Prod/Staging/Test × Cup/Chub/Stream) — no other CF drift detected beyond the missing scan segment vars. All Lambda functions have consistent runtime, memory, timeout, architecture, and env var configurations across environments.

## Jira
https://chb.atlassian.net/browse/ES-2966

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CloudFormation-managed configuration for multiple Lambdas (memory/timeout/env vars), which can affect runtime behavior and performance across environments. Risk is mitigated by being primarily resource sizing/parameter wiring, but mis-set parameters could impact DynamoDB scan load or API latency.
> 
> **Overview**
> **Codifies DynamoDB scan parallelism settings in CloudFormation.** Adds `BotScanSegments` and `QueueScanSegments` stack parameters (default `"1"`) and wires them into `BOT_SCAN_SEGMENTS`/`QUEUE_SCAN_SEGMENTS` env vars for `api/stats` and `bots/healthSNS` so values persist across deploys.
> 
> **Restores/aligns Lambda resource configuration in source.** Bumps `config.leo.memory` from 256→512 for several API handlers (cron, event settings, logs, settings, sns, system, and health check) and increases `api/stats` timeout from 10s→30s to match expected production settings. Also bumps root `package.json` version to `3.0.7` and adds a `v3.0.7` changelog documenting these fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 823216139f1e2fe5ce708b5408789afcec4b2785. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->