### PR TITLE
fix(botmon): Lambda memory 512 MB for APIs (ES-2958)

### DIFF
--- a/api/cron/delete/package.json
+++ b/api/cron/delete/package.json
@@ -20,7 +20,7 @@
 			],
 			"name": "Leo_Botmon_api_cron_delete",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"build": {}
 		}

--- a/api/cron/get/package.json
+++ b/api/cron/get/package.json
@@ -21,7 +21,7 @@
 			],
 			"name": "Leo_Botmon_api_cron_get",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"build": {}
 		}

--- a/api/cron/save/package.json
+++ b/api/cron/save/package.json
@@ -20,7 +20,7 @@
 			],
 			"name": "Leo_Botmon_api_cron_save",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"build": {}
 		}

--- a/api/cron/saveOverrides/package.json
+++ b/api/cron/saveOverrides/package.json
@@ -17,7 +17,7 @@
 			],
 			"name": "Leo_Botmon_api_setting_saveOverrides",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"build": {}
 		}

--- a/api/eventSettings/get/package.json
+++ b/api/eventSettings/get/package.json
@@ -20,7 +20,7 @@
 			],
 			"name": "Leo_Botmon_api_event_settings_get",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"build": {}
 		}

--- a/api/eventSettings/save/package.json
+++ b/api/eventSettings/save/package.json
@@ -20,7 +20,7 @@
 			],
 			"name": "Leo_Botmon_api_event_settings_save",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"build": {}
 		}

--- a/api/logs/package.json
+++ b/api/logs/package.json
@@ -16,7 +16,7 @@
 			"name": "Leo_Botmon_api_logs",
 			"handler": "handler",
 			"role": null,
-			"memory": 256,
+			"memory": 512,
 			"timeout": 30,
 			"env": {
 				"Resources": {

--- a/api/settings/package.json
+++ b/api/settings/package.json
@@ -18,7 +18,7 @@
 			],
 			"name": "Leo_Botmon_api_settings",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"env": {
 				"Resources": {

--- a/api/sns/package.json
+++ b/api/sns/package.json
@@ -18,7 +18,7 @@
 			],
 			"name": "Leo_Botmon_api_sns",
 			"handler": "handler",
-			"memory": 256,
+			"memory": 512,
 			"timeout": 30,
 			"build": {},
 			"env": {

--- a/api/system/get/package.json
+++ b/api/system/get/package.json
@@ -16,7 +16,7 @@
 			"name": "Leo_Botmon_api_system_get",
 			"handler": "handler",
 			"role": null,
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10
 		}
 	},

--- a/api/system/save/package.json
+++ b/api/system/save/package.json
@@ -19,7 +19,7 @@
 			"name": "Leo_Botmon_api_system_save",
 			"handler": "handler",
 			"role": null,
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10
 		}
 	},

--- a/bots/healthSNS/package.json
+++ b/bots/healthSNS/package.json
@@ -18,7 +18,7 @@
 					"ref": "core.roles.LeoHealthCheckRole"
 				}
 			},
-			"memory": 256,
+			"memory": 512,
 			"timeout": 10,
 			"cron": {
 				"owner": "leo",


### PR DESCRIPTION
## Summary
Raises `config.leo.memory` from 256 MB to 512 MB for twelve Botmon Lambdas whose CloudFormation templates were deployed at 256 MB on 2026-03-19. That change caused **Runtime.OutOfMemory** during INIT (CronGetApi used ~438–440 MB in prod), which surfaced to users as **502** from API Gateway.

This matches the **manual `update-function-configuration`** applied 2026-03-23 across all nine stacks so the next deploy from master does not revert memory to 256 MB.

## Task reference
- Jira: https://chb.atlassian.net/browse/ES-2958

## Functions (package.json paths)
- `api/cron/get`, `save`, `delete`, `saveOverrides`
- `api/logs`
- `api/eventSettings/get`, `save`
- `api/settings`, `api/sns`
- `api/system/get`, `save`
- `bots/healthSNS` (LeoHealthCheck cron)

## Testing
- Config-only change; no runtime code paths modified. Deploy verification: confirm CloudFormation `MemorySize` 512 on the above logical resources after publish.

## Notes
- ProdStreamBotmon StatsApi timeout / LeoStats size is out of scope (per ES-2958 investigation).
- `api/system/proxy` remains at 256 MB (`skip: true`); it was not part of the manual twelve-function bump.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that adjusts Lambda `MemorySize`, primarily impacting runtime capacity and cost rather than logic or data handling.
> 
> **Overview**
> Raises `config.leo.memory` from **256 → 512 MB** across the Botmon Cron, EventSettings/Queue, Logs, Settings, SNS, and System API Lambdas, plus the `bots/healthSNS` cron.
> 
> No runtime code changes; this ensures future deployments keep the higher memory setting to avoid `Runtime.OutOfMemory` failures and resulting API Gateway 502s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cd414f1575284dbf73d0305e755b5f3d3e8579d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->