### PR TITLE
fix(webapp): honor header time picker for queue event search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,24 @@ SvelteKit 2 + Svelte 5 webapp that monitors LEO Platform (serverless ETL). Deplo
 - **AWS**: SDK v3, Leo SDK 7.1.18, Cognito Identity Pool for client credential minting
 - **Deploy**: SST v3 → Lambda (arm64, 1GB, 30s) + CloudFront + API Gateway v1
 
+## Application version (SvelteKit Botmon)
+
+**Source of truth:** `webapp/package.json` → `version` (semver **4.x.y**). That is the **new** Botmon (`webapp/`). The **repo root** `package.json` version (3.x) is the **legacy** webpack Botmon — bump it only when you change the old UI bundle, not for SvelteKit-only work.
+
+**Agents must bump `webapp` version on every PR** that changes anything that ships in the deployed SvelteKit app (features, bug fixes, deploy-facing config, security patches). Do not merge behavior changes with an unchanged `webapp` version — it is how operators and support correlate builds to tickets.
+
+1. `cd webapp`
+2. Choose semver bump (default is patch):
+   - **Patch** — fixes, small UX, internal refactors that deploy:  
+     `npm version patch --no-git-tag-version`
+   - **Minor** — new user-visible capability, backward-compatible API:  
+     `npm version minor --no-git-tag-version`
+   - **Major** — rare; breaking operator/auth/API contract:  
+     `npm version major --no-git-tag-version`
+3. Commit the updated `package.json` and `package-lock.json` in the **same PR** as the code (same commit or the next commit on that branch).
+
+`--no-git-tag-version` skips creating a `git tag` locally (CI or release process may tag after merge).
+
 ## Architecture
 
 All app code is under `webapp/src/`:

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botmon",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "botmon",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.1030.0",
         "@aws-sdk/client-cognito-identity": "^3.1030.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "botmon",
   "private": true,
-  "version": "4.0.0",
+  "version": "4.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/webapp/src/lib/client/components/features/dashboard/queue-events-tab.svelte
+++ b/webapp/src/lib/client/components/features/dashboard/queue-events-tab.svelte
@@ -45,6 +45,8 @@
 
     const appState = getContext<AppState>("appState");
     const compState = appState.dashboardState;
+    /** Same “as of” instant as dashboard stats (header calendar / bucket navigation). */
+    const timePicker = appState.timePickerState;
 
     let settings = $derived(compState.settings as { latest_write?: number; max_eid?: string } | undefined);
 
@@ -302,8 +304,13 @@
         chainRunning = false;
     }
 
+    /** Right edge of the visible time window; matches `DashboardState.getDashStats` timestamp. */
+    function searchAnchorUtcMs(): number {
+        return timePicker.endTime ?? Date.now();
+    }
+
     function tokenFromTimeFrame(): string {
-        return buildZTokenFromUtcMs(Date.now() - DURATION_MS[activeTimeFrame]);
+        return buildZTokenFromUtcMs(searchAnchorUtcMs() - DURATION_MS[activeTimeFrame]);
     }
 
     /** User-initiated search (Enter key in search bar). */
@@ -440,14 +447,18 @@
     });
 
     /**
-     * Re-fetch events when the queue ID or time picker changes.
-     * Tracks startTime + endTime so we re-run on bucket navigation and live/historical toggle.
+     * Re-fetch events when the queue ID or global time picker changes (calendar, prev/next bucket, live vs historical).
+     * Reads `endTime` / `startTime` so Svelte tracks the same window the dashboard header controls.
      * searchText is read inside runPayloadSearchChain but via untrack so it
      * doesn't cause this effect to re-fire on every keystroke.
      */
     $effect(() => {
         const id = queueId;
         if (!id) return;
+
+        // Reactive deps: global time range (see `TimePickerState`, wired in `dashboard.svelte`)
+        void timePicker.endTime;
+        void timePicker.startTime;
 
         cancelSearch();
         abortCtrl = new AbortController();


### PR DESCRIPTION
## Summary
Queue **Events** tab payload search always built its start z-token from `Date.now()`, ignoring the global header time picker. Search now uses the same anchor as dashboard stats (`timePicker.endTime ?? Date.now()`) and refetches when the picker window changes.

## Task reference
- Jira: https://chb.atlassian.net/browse/ES-3084
- Genie task: ES-3084

## Changes
- `queue-events-tab.svelte`: `searchAnchorUtcMs()`, wire `tokenFromTimeFrame()` to it, read `timePicker.startTime` / `endTime` in the initial search `$effect` for reactive deps.
- `webapp/package.json`: bump Botmon app version to **4.0.1** (see `AGENTS.md` for semver policy).
- `AGENTS.md`: document required `webapp` version bumps for shipped SvelteKit changes.

## Testing
1. Open a queue dashboard, **Events** tab.
2. Expand the header time range, pick a historical date/time (or use prev/next bucket), apply.
3. Confirm the event list refreshes around that window (not always "today").
4. Optional: use **Now** and confirm search returns to current time.

### Commands run (local)
- `cd webapp && npm install` — success.
- `npm run check` — fails with existing project errors (46+), none in the changed file.
- `npx eslint .../queue-events-tab.svelte` — reports pre-existing issues in that file (`any`, each-key); unchanged by this PR.
- `npm test` — Vitest did not complete in this environment (Playwright browser binary missing; vite dep-scan noise).

## Checklist
- [x] Scoped change; primary clone untouched
- [x] Self-review

Made with [Cursor](https://cursor.com)
