### PR TITLE
ES-3031 bus-ui: migrate Chart.js charts to LayerChart

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -20,8 +20,6 @@
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "async": "^3.2.6",
-        "chart.js": "^4.5.0",
-        "chartjs-plugin-annotation": "^3.1.0",
         "d3": "^7.9.0",
         "diff": "^5.2.2",
         "fuse.js": "^7.1.0",
@@ -1315,6 +1313,7 @@
       "version": "3.817.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.817.0.tgz",
       "integrity": "sha512-UXHY1cOsPTyrzRY+8yJUYcD7dnMHbP2hoFRhNOiMCMqjKV4lRRQ/1EiLxX5aohAYkxxr2kOqSDFjzq9wbtX6PQ==",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1766,7 +1765,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-firehose/-/client-firehose-3.859.0.tgz",
       "integrity": "sha512-ZCaQN4+yDW4KoHKPVQB8Zn/EsVEpcFM56AsrTd43nKPQYOKtxFWZCwx4VvEz4K+sLV5AvX4yM3OTw572MmrHmg==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1816,7 +1814,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.858.0.tgz",
       "integrity": "sha512-iXuZQs4KH6a3Pwnt0uORalzAZ5EXRPr3lBYAsdNwkP8OYyoUz5/TE3BLyw7ceEh0rj4QKGNnNALYo1cDm0EV8w==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1865,7 +1862,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.858.0.tgz",
       "integrity": "sha512-iWm4QLAS+/XMlnecIU1Y33qbBr1Ju+pmWam3xVCPlY4CSptKpVY+2hXOnmg9SbHAX9C005fWhrIn51oDd00c9A==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@aws-sdk/xml-builder": "3.821.0",
@@ -1891,7 +1887,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.858.0.tgz",
       "integrity": "sha512-kZsGyh2BoSRguzlcGtzdLhw/l/n3KYAC+/l/H0SlsOq3RLHF6tO/cRdsLnwoix2bObChHUp03cex63o1gzdx/Q==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -1907,7 +1902,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.858.0.tgz",
       "integrity": "sha512-GDnfYl3+NPJQ7WQQYOXEA489B212NinpcIDD7rpsB6IWUPo8yDjT5NceK4uUkIR3MFpNCGt9zd/z6NNLdB2fuQ==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -1928,7 +1922,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.859.0.tgz",
       "integrity": "sha512-KsccE1T88ZDNhsABnqbQj014n5JMDilAroUErFbGqu5/B3sXqUsYmG54C/BjvGTRUFfzyttK9lB9P9h6ddQ8Cw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/credential-provider-env": "3.858.0",
@@ -1952,7 +1945,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.859.0.tgz",
       "integrity": "sha512-ZRDB2xU5aSyTR/jDcli30tlycu6RFvQngkZhBs9Zoh2BiYXrfh2MMuoYuZk+7uD6D53Q2RIEldDHR9A/TPlRuA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.858.0",
         "@aws-sdk/credential-provider-http": "3.858.0",
@@ -1975,7 +1967,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.858.0.tgz",
       "integrity": "sha512-l5LJWZJMRaZ+LhDjtupFUKEC5hAjgvCRrOvV5T60NCUBOy0Ozxa7Sgx3x+EOwiruuoh3Cn9O+RlbQlJX6IfZIw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -1992,7 +1983,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.859.0.tgz",
       "integrity": "sha512-BwAqmWIivhox5YlFRjManFF8GoTvEySPk6vsJNxDsmGsabY+OQovYxFIYxRCYiHzH7SFjd4Lcd+riJOiXNsvRw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.858.0",
         "@aws-sdk/core": "3.858.0",
@@ -2011,7 +2001,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.858.0.tgz",
       "integrity": "sha512-8iULWsH83iZDdUuiDsRb83M0NqIlXjlDbJUIddVsIrfWp4NmanKw77SV6yOZ66nuJjPsn9j7RDb9bfEPCy5SWA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/nested-clients": "3.858.0",
@@ -2028,7 +2017,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz",
       "integrity": "sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/protocol-http": "^5.1.2",
@@ -2043,7 +2031,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz",
       "integrity": "sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
@@ -2057,7 +2044,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz",
       "integrity": "sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/protocol-http": "^5.1.2",
@@ -2072,7 +2058,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.858.0.tgz",
       "integrity": "sha512-pC3FT/sRZ6n5NyXiTVu9dpf1D9j3YbJz3XmeOOwJqO/Mib2PZyIQktvNMPgwaC5KMVB1zWqS5bmCwxpMOnq0UQ==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -2090,7 +2075,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.858.0.tgz",
       "integrity": "sha512-ChdIj80T2whoWbovmO7o8ICmhEB2S9q4Jes9MBnKAPm69PexcJAK2dQC8yI4/iUP8b3+BHZoUPrYLWjBxIProQ==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2139,7 +2123,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz",
       "integrity": "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/node-config-provider": "^4.1.3",
@@ -2156,7 +2139,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.859.0.tgz",
       "integrity": "sha512-6P2wlvm9KBWOvRNn0Pt8RntnXg8fzOb5kEShvWsOsAocZeqKNaYbihum5/Onq1ZPoVtkdb++8eWDocDnM4k85Q==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/nested-clients": "3.858.0",
@@ -2174,7 +2156,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
       "integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -2187,7 +2168,6 @@
       "version": "3.848.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
       "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
@@ -2203,7 +2183,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
       "integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
@@ -2215,7 +2194,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.858.0.tgz",
       "integrity": "sha512-T1m05QlN8hFpx5/5duMjS8uFSK5e6EXP45HQRkZULVkL3DK+jMaxsnh3KLl5LjUoHn/19M4HM0wNUBhYp4Y2Yw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -2245,7 +2223,6 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "peer": true,
       "dependencies": {
         "strnum": "^2.1.0"
       },
@@ -2262,14 +2239,12 @@
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@aws-sdk/client-kinesis": {
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.859.0.tgz",
       "integrity": "sha512-ad2/PQMO08lg9ZIpo1TtOR45+siJI3iLo/3FFGdnce15fcdhoKRrOhvPWekgVCwXOFmq7Uc9squOoXXNkeDocw==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2323,7 +2298,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.858.0.tgz",
       "integrity": "sha512-iXuZQs4KH6a3Pwnt0uORalzAZ5EXRPr3lBYAsdNwkP8OYyoUz5/TE3BLyw7ceEh0rj4QKGNnNALYo1cDm0EV8w==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2372,7 +2346,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.858.0.tgz",
       "integrity": "sha512-iWm4QLAS+/XMlnecIU1Y33qbBr1Ju+pmWam3xVCPlY4CSptKpVY+2hXOnmg9SbHAX9C005fWhrIn51oDd00c9A==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@aws-sdk/xml-builder": "3.821.0",
@@ -2398,7 +2371,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.858.0.tgz",
       "integrity": "sha512-kZsGyh2BoSRguzlcGtzdLhw/l/n3KYAC+/l/H0SlsOq3RLHF6tO/cRdsLnwoix2bObChHUp03cex63o1gzdx/Q==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -2414,7 +2386,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.858.0.tgz",
       "integrity": "sha512-GDnfYl3+NPJQ7WQQYOXEA489B212NinpcIDD7rpsB6IWUPo8yDjT5NceK4uUkIR3MFpNCGt9zd/z6NNLdB2fuQ==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -2435,7 +2406,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.859.0.tgz",
       "integrity": "sha512-KsccE1T88ZDNhsABnqbQj014n5JMDilAroUErFbGqu5/B3sXqUsYmG54C/BjvGTRUFfzyttK9lB9P9h6ddQ8Cw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/credential-provider-env": "3.858.0",
@@ -2459,7 +2429,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.859.0.tgz",
       "integrity": "sha512-ZRDB2xU5aSyTR/jDcli30tlycu6RFvQngkZhBs9Zoh2BiYXrfh2MMuoYuZk+7uD6D53Q2RIEldDHR9A/TPlRuA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.858.0",
         "@aws-sdk/credential-provider-http": "3.858.0",
@@ -2482,7 +2451,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.858.0.tgz",
       "integrity": "sha512-l5LJWZJMRaZ+LhDjtupFUKEC5hAjgvCRrOvV5T60NCUBOy0Ozxa7Sgx3x+EOwiruuoh3Cn9O+RlbQlJX6IfZIw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -2499,7 +2467,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.859.0.tgz",
       "integrity": "sha512-BwAqmWIivhox5YlFRjManFF8GoTvEySPk6vsJNxDsmGsabY+OQovYxFIYxRCYiHzH7SFjd4Lcd+riJOiXNsvRw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.858.0",
         "@aws-sdk/core": "3.858.0",
@@ -2518,7 +2485,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.858.0.tgz",
       "integrity": "sha512-8iULWsH83iZDdUuiDsRb83M0NqIlXjlDbJUIddVsIrfWp4NmanKw77SV6yOZ66nuJjPsn9j7RDb9bfEPCy5SWA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/nested-clients": "3.858.0",
@@ -2535,7 +2501,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz",
       "integrity": "sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/protocol-http": "^5.1.2",
@@ -2550,7 +2515,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz",
       "integrity": "sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
@@ -2564,7 +2528,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz",
       "integrity": "sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/protocol-http": "^5.1.2",
@@ -2579,7 +2542,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.858.0.tgz",
       "integrity": "sha512-pC3FT/sRZ6n5NyXiTVu9dpf1D9j3YbJz3XmeOOwJqO/Mib2PZyIQktvNMPgwaC5KMVB1zWqS5bmCwxpMOnq0UQ==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -2597,7 +2559,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.858.0.tgz",
       "integrity": "sha512-ChdIj80T2whoWbovmO7o8ICmhEB2S9q4Jes9MBnKAPm69PexcJAK2dQC8yI4/iUP8b3+BHZoUPrYLWjBxIProQ==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2646,7 +2607,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz",
       "integrity": "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/node-config-provider": "^4.1.3",
@@ -2663,7 +2623,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.859.0.tgz",
       "integrity": "sha512-6P2wlvm9KBWOvRNn0Pt8RntnXg8fzOb5kEShvWsOsAocZeqKNaYbihum5/Onq1ZPoVtkdb++8eWDocDnM4k85Q==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/nested-clients": "3.858.0",
@@ -2681,7 +2640,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
       "integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -2694,7 +2652,6 @@
       "version": "3.848.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
       "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
@@ -2710,7 +2667,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
       "integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
@@ -2722,7 +2678,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.858.0.tgz",
       "integrity": "sha512-T1m05QlN8hFpx5/5duMjS8uFSK5e6EXP45HQRkZULVkL3DK+jMaxsnh3KLl5LjUoHn/19M4HM0wNUBhYp4Y2Yw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -2752,7 +2707,6 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "peer": true,
       "dependencies": {
         "strnum": "^2.1.0"
       },
@@ -2769,14 +2723,12 @@
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@aws-sdk/client-lambda": {
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.859.0.tgz",
       "integrity": "sha512-p9/6TrAESLLajn9ytJs6S6ErXyyEbxlO6v44oPXiDeNRKVQxevkG+brAfHDmh7dZk9EQkmyp5AWqo1dZrpkhdg==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2831,7 +2783,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.858.0.tgz",
       "integrity": "sha512-iXuZQs4KH6a3Pwnt0uORalzAZ5EXRPr3lBYAsdNwkP8OYyoUz5/TE3BLyw7ceEh0rj4QKGNnNALYo1cDm0EV8w==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2880,7 +2831,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.858.0.tgz",
       "integrity": "sha512-iWm4QLAS+/XMlnecIU1Y33qbBr1Ju+pmWam3xVCPlY4CSptKpVY+2hXOnmg9SbHAX9C005fWhrIn51oDd00c9A==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@aws-sdk/xml-builder": "3.821.0",
@@ -2906,7 +2856,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.858.0.tgz",
       "integrity": "sha512-kZsGyh2BoSRguzlcGtzdLhw/l/n3KYAC+/l/H0SlsOq3RLHF6tO/cRdsLnwoix2bObChHUp03cex63o1gzdx/Q==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -2922,7 +2871,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.858.0.tgz",
       "integrity": "sha512-GDnfYl3+NPJQ7WQQYOXEA489B212NinpcIDD7rpsB6IWUPo8yDjT5NceK4uUkIR3MFpNCGt9zd/z6NNLdB2fuQ==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -2943,7 +2891,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.859.0.tgz",
       "integrity": "sha512-KsccE1T88ZDNhsABnqbQj014n5JMDilAroUErFbGqu5/B3sXqUsYmG54C/BjvGTRUFfzyttK9lB9P9h6ddQ8Cw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/credential-provider-env": "3.858.0",
@@ -2967,7 +2914,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.859.0.tgz",
       "integrity": "sha512-ZRDB2xU5aSyTR/jDcli30tlycu6RFvQngkZhBs9Zoh2BiYXrfh2MMuoYuZk+7uD6D53Q2RIEldDHR9A/TPlRuA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.858.0",
         "@aws-sdk/credential-provider-http": "3.858.0",
@@ -2990,7 +2936,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.858.0.tgz",
       "integrity": "sha512-l5LJWZJMRaZ+LhDjtupFUKEC5hAjgvCRrOvV5T60NCUBOy0Ozxa7Sgx3x+EOwiruuoh3Cn9O+RlbQlJX6IfZIw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -3007,7 +2952,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.859.0.tgz",
       "integrity": "sha512-BwAqmWIivhox5YlFRjManFF8GoTvEySPk6vsJNxDsmGsabY+OQovYxFIYxRCYiHzH7SFjd4Lcd+riJOiXNsvRw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.858.0",
         "@aws-sdk/core": "3.858.0",
@@ -3026,7 +2970,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.858.0.tgz",
       "integrity": "sha512-8iULWsH83iZDdUuiDsRb83M0NqIlXjlDbJUIddVsIrfWp4NmanKw77SV6yOZ66nuJjPsn9j7RDb9bfEPCy5SWA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/nested-clients": "3.858.0",
@@ -3043,7 +2986,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz",
       "integrity": "sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/protocol-http": "^5.1.2",
@@ -3058,7 +3000,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz",
       "integrity": "sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
@@ -3072,7 +3013,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz",
       "integrity": "sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/protocol-http": "^5.1.2",
@@ -3087,7 +3027,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.858.0.tgz",
       "integrity": "sha512-pC3FT/sRZ6n5NyXiTVu9dpf1D9j3YbJz3XmeOOwJqO/Mib2PZyIQktvNMPgwaC5KMVB1zWqS5bmCwxpMOnq0UQ==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -3105,7 +3044,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.858.0.tgz",
       "integrity": "sha512-ChdIj80T2whoWbovmO7o8ICmhEB2S9q4Jes9MBnKAPm69PexcJAK2dQC8yI4/iUP8b3+BHZoUPrYLWjBxIProQ==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -3154,7 +3092,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz",
       "integrity": "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/node-config-provider": "^4.1.3",
@@ -3171,7 +3108,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.859.0.tgz",
       "integrity": "sha512-6P2wlvm9KBWOvRNn0Pt8RntnXg8fzOb5kEShvWsOsAocZeqKNaYbihum5/Onq1ZPoVtkdb++8eWDocDnM4k85Q==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/nested-clients": "3.858.0",
@@ -3189,7 +3125,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
       "integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -3202,7 +3137,6 @@
       "version": "3.848.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
       "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
@@ -3218,7 +3152,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
       "integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
@@ -3230,7 +3163,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.858.0.tgz",
       "integrity": "sha512-T1m05QlN8hFpx5/5duMjS8uFSK5e6EXP45HQRkZULVkL3DK+jMaxsnh3KLl5LjUoHn/19M4HM0wNUBhYp4Y2Yw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -3260,7 +3192,6 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "peer": true,
       "dependencies": {
         "strnum": "^2.1.0"
       },
@@ -3277,8 +3208,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.1012.0",
@@ -4767,7 +4697,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.859.0.tgz",
       "integrity": "sha512-pWZGAmg26/45lrUw3oEzLf+YIHy1C9x3fFyy/mtQe0AtDsJX+7r4OJ7AToZHS/qZbkoUb9AbA5Y/jG4nEhCILw==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -4817,7 +4746,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.858.0.tgz",
       "integrity": "sha512-iXuZQs4KH6a3Pwnt0uORalzAZ5EXRPr3lBYAsdNwkP8OYyoUz5/TE3BLyw7ceEh0rj4QKGNnNALYo1cDm0EV8w==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -4866,7 +4794,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.858.0.tgz",
       "integrity": "sha512-iWm4QLAS+/XMlnecIU1Y33qbBr1Ju+pmWam3xVCPlY4CSptKpVY+2hXOnmg9SbHAX9C005fWhrIn51oDd00c9A==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@aws-sdk/xml-builder": "3.821.0",
@@ -4892,7 +4819,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.858.0.tgz",
       "integrity": "sha512-kZsGyh2BoSRguzlcGtzdLhw/l/n3KYAC+/l/H0SlsOq3RLHF6tO/cRdsLnwoix2bObChHUp03cex63o1gzdx/Q==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -4908,7 +4834,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.858.0.tgz",
       "integrity": "sha512-GDnfYl3+NPJQ7WQQYOXEA489B212NinpcIDD7rpsB6IWUPo8yDjT5NceK4uUkIR3MFpNCGt9zd/z6NNLdB2fuQ==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -4929,7 +4854,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.859.0.tgz",
       "integrity": "sha512-KsccE1T88ZDNhsABnqbQj014n5JMDilAroUErFbGqu5/B3sXqUsYmG54C/BjvGTRUFfzyttK9lB9P9h6ddQ8Cw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/credential-provider-env": "3.858.0",
@@ -4953,7 +4877,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.859.0.tgz",
       "integrity": "sha512-ZRDB2xU5aSyTR/jDcli30tlycu6RFvQngkZhBs9Zoh2BiYXrfh2MMuoYuZk+7uD6D53Q2RIEldDHR9A/TPlRuA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.858.0",
         "@aws-sdk/credential-provider-http": "3.858.0",
@@ -4976,7 +4899,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.858.0.tgz",
       "integrity": "sha512-l5LJWZJMRaZ+LhDjtupFUKEC5hAjgvCRrOvV5T60NCUBOy0Ozxa7Sgx3x+EOwiruuoh3Cn9O+RlbQlJX6IfZIw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -4993,7 +4915,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.859.0.tgz",
       "integrity": "sha512-BwAqmWIivhox5YlFRjManFF8GoTvEySPk6vsJNxDsmGsabY+OQovYxFIYxRCYiHzH7SFjd4Lcd+riJOiXNsvRw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.858.0",
         "@aws-sdk/core": "3.858.0",
@@ -5012,7 +4933,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.858.0.tgz",
       "integrity": "sha512-8iULWsH83iZDdUuiDsRb83M0NqIlXjlDbJUIddVsIrfWp4NmanKw77SV6yOZ66nuJjPsn9j7RDb9bfEPCy5SWA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/nested-clients": "3.858.0",
@@ -5029,7 +4949,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz",
       "integrity": "sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/protocol-http": "^5.1.2",
@@ -5044,7 +4963,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz",
       "integrity": "sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
@@ -5058,7 +4976,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz",
       "integrity": "sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/protocol-http": "^5.1.2",
@@ -5073,7 +4990,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.858.0.tgz",
       "integrity": "sha512-pC3FT/sRZ6n5NyXiTVu9dpf1D9j3YbJz3XmeOOwJqO/Mib2PZyIQktvNMPgwaC5KMVB1zWqS5bmCwxpMOnq0UQ==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -5091,7 +5007,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.858.0.tgz",
       "integrity": "sha512-ChdIj80T2whoWbovmO7o8ICmhEB2S9q4Jes9MBnKAPm69PexcJAK2dQC8yI4/iUP8b3+BHZoUPrYLWjBxIProQ==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -5140,7 +5055,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz",
       "integrity": "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/node-config-provider": "^4.1.3",
@@ -5157,7 +5071,6 @@
       "version": "3.859.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.859.0.tgz",
       "integrity": "sha512-6P2wlvm9KBWOvRNn0Pt8RntnXg8fzOb5kEShvWsOsAocZeqKNaYbihum5/Onq1ZPoVtkdb++8eWDocDnM4k85Q==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.858.0",
         "@aws-sdk/nested-clients": "3.858.0",
@@ -5175,7 +5088,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
       "integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -5188,7 +5100,6 @@
       "version": "3.848.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
       "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
@@ -5204,7 +5115,6 @@
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
       "integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
@@ -5216,7 +5126,6 @@
       "version": "3.858.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.858.0.tgz",
       "integrity": "sha512-T1m05QlN8hFpx5/5duMjS8uFSK5e6EXP45HQRkZULVkL3DK+jMaxsnh3KLl5LjUoHn/19M4HM0wNUBhYp4Y2Yw==",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "3.858.0",
         "@aws-sdk/types": "3.840.0",
@@ -5246,7 +5155,6 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "peer": true,
       "dependencies": {
         "strnum": "^2.1.0"
       },
@@ -5263,8 +5171,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@aws-sdk/core": {
       "version": "3.775.0",
@@ -5785,6 +5692,7 @@
       "version": "3.787.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.787.0.tgz",
       "integrity": "sha512-kR3RtI7drOc9pho13vWbUC2Bvrx9A0G4iizBDGmTs08NOdg4w3c1I4kdLG9tyPiIMeVnH+wYrsli5CM7xIfqiA==",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-cognito-identity": "3.787.0",
         "@aws-sdk/core": "3.775.0",
@@ -6554,7 +6462,6 @@
       "version": "3.821.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz",
       "integrity": "sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -7512,6 +7419,7 @@
       "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -7608,11 +7516,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
     },
     "node_modules/@layerstack/svelte-actions": {
       "version": "1.0.1-next.14",
@@ -8161,7 +8064,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
       "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
@@ -9358,6 +9260,7 @@
       "integrity": "sha512-74g07+mUq9Cfm9XStP/jLf1wqOgirPnj4WM0BOHMFolSjUwG58LIsAniB7O5PH7we0tf1+Qvj6Cjws2qUiB9/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/components": "8.6.12",
         "@storybook/csf": "0.1.12",
@@ -9574,6 +9477,7 @@
       "integrity": "sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -9623,6 +9527,7 @@
       "integrity": "sha512-MCFS6CrQDu1yGwspm4qtli0e63vaPCehf6V7pIMP15AsWgMKrqDGCPFF/0kn4SP0ii4aySu4Pa62+fIRGFMjgw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.0",
@@ -9976,6 +9881,7 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -10374,6 +10280,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
       "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -10464,6 +10371,7 @@
       "integrity": "sha512-5w64ZeRCgWOA/2ADPoFYmDYdPnEeEkUiFx5Sez7MQpQuxVazHO9wwl+wElokaY5hMKVVor1N13z/tZeWYfVaUg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.30.0",
         "@typescript-eslint/types": "8.30.0",
@@ -10646,6 +10554,7 @@
       "integrity": "sha512-A+A69mMtrj1RPh96LfXGc309KSXhy2MslvyL+cp9+Y5EVdoJD4KfXDx/3SSlRGN70+hIoJ3RRbTidTvj18PZ/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -10875,6 +10784,7 @@
       "integrity": "sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.1.1",
         "pathe": "^2.0.3"
@@ -11007,6 +10917,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11463,6 +11374,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -11480,7 +11392,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
       "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -11657,25 +11568,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chart.js": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
-      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
-      }
-    },
-    "node_modules/chartjs-plugin-annotation": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-3.1.0.tgz",
-      "integrity": "sha512-EkAed6/ycXD/7n0ShrlT1T2Hm3acnbFhgkIEJLa0X+M6S16x0zwj1Fv4suv/2bwayCT3jGPdAtI9uLcAMToaQQ==",
-      "peerDependencies": {
-        "chart.js": ">=4.0.0"
       }
     },
     "node_modules/check-error": {
@@ -11959,8 +11851,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3": {
       "version": "7.9.0",
@@ -12330,6 +12221,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12926,6 +12818,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -13008,6 +12901,7 @@
       "integrity": "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -13312,7 +13206,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -14117,8 +14010,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -15970,21 +15862,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/pkce-challenge": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
@@ -16084,6 +15961,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -16099,6 +15977,7 @@
       "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lilconfig": "^2.0.5",
         "yaml": "^1.10.2"
@@ -16212,6 +16091,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "dev": true,
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -16479,6 +16359,7 @@
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16505,6 +16386,7 @@
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -17379,6 +17261,7 @@
       "integrity": "sha512-Z/nWYEHBTLK1ZBtAWdhxC0l5zf7ioJ7G4+zYqtTdYeb67gTnxNj80gehf8o8QY9L2zA2+eyMRGLC2V5fI7Z3Tw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/core": "8.6.12"
       },
@@ -17404,7 +17287,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
       "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-      "peer": true,
       "dependencies": {
         "inherits": "~2.0.4",
         "readable-stream": "^3.5.0"
@@ -17414,7 +17296,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -17621,6 +17502,7 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.35.2.tgz",
       "integrity": "sha512-uW/rRXYrhZ7Dh4UQNZ0t+oVGL1dEM+95GavCO8afAk1IY2cPq9BcZv9C3um5aLIya2y8lIeLPxLII9ASGg9Dzw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -18189,7 +18071,8 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.2.2",
@@ -18436,6 +18319,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -18501,6 +18385,7 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
       "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -18596,6 +18481,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18937,6 +18823,7 @@
       "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "postcss": "^8.5.3",
@@ -19051,6 +18938,7 @@
       "integrity": "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.1.1",
         "@vitest/mocker": "3.1.1",
@@ -19409,21 +19297,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -19517,6 +19390,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.7.tgz",
       "integrity": "sha512-YGdT1cVRmKkOg6Sq7vY7IkxdphySKnXhaUmFI4r4FcuFVNgpCb9tZfNwXbT6BPjD5oz0nubFsoo9pIqKrDcCvg==",
       "dev": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -97,8 +97,6 @@
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "async": "^3.2.6",
-    "chart.js": "^4.5.0",
-    "chartjs-plugin-annotation": "^3.1.0",
     "d3": "^7.9.0",
     "diff": "^5.2.2",
     "fuse.js": "^7.1.0",

--- a/webapp/src/lib/client/components/features/charts/bucket-totals.ts
+++ b/webapp/src/lib/client/components/features/charts/bucket-totals.ts
@@ -1,0 +1,77 @@
+import type { DashboardStatsValue } from "$lib/types";
+
+/**
+ * Pure aggregation behind the bucket line chart's three "total" rows.
+ *
+ * Extracted from generic-bucket-line-chart.svelte during the Chart.js -> LayerChart
+ * migration (ES-3031) so the numbers shown to users can be regression-tested without
+ * rendering. The rendering library changed; these sums must NOT. Boundary rules and
+ * override precedence are preserved exactly from the original inline logic.
+ */
+export interface BucketTotalsInput {
+  data: DashboardStatsValue[] | null;
+  /** Start of the current stats bucket (API currentBucketStart). */
+  start: number;
+  /** End of the query window (API end / time-picker end). */
+  end: number;
+  /** Start of the query window used for the blue "total" row (API start, aligned). */
+  effectiveRangeStart: number;
+  /** Start of the previous ("last") bucket. */
+  lastBucket: number;
+  /** When finite, wins over the computed totalCount. */
+  overrideTotal?: number;
+  /** When finite, wins over the computed countInBucket. */
+  overrideCountInBucket?: number;
+  /** When finite, wins over the computed countInLastBucket. */
+  overrideCountInLastBucket?: number;
+}
+
+export interface BucketTotals {
+  /** Sum of values with time in [start, end] (inclusive). */
+  countInBucket: number;
+  /** Sum of values with time in [effectiveRangeStart, end] (inclusive). */
+  totalCount: number;
+  /** Sum of values with time in [lastBucket, start) (half-open — excludes start). */
+  countInLastBucket: number;
+}
+
+/** Use `override` only when it is a finite number; otherwise fall back to the computed value. */
+const finiteOr = (n: number | undefined, fallback: number): number =>
+  typeof n === "number" && Number.isFinite(n) ? n : fallback;
+
+const sumWhere = (
+  data: DashboardStatsValue[] | null,
+  inWindow: (time: number) => boolean
+): number =>
+  (data ?? []).reduce(
+    (acc, p) => (inWindow(p.time) ? acc + (Number(p.value) || 0) : acc),
+    0
+  );
+
+export function computeBucketTotals(input: BucketTotalsInput): BucketTotals {
+  const {
+    data,
+    start,
+    end,
+    effectiveRangeStart,
+    lastBucket,
+    overrideTotal,
+    overrideCountInBucket,
+    overrideCountInLastBucket,
+  } = input;
+
+  return {
+    countInBucket: finiteOr(
+      overrideCountInBucket,
+      sumWhere(data, (t) => t >= start && t <= end)
+    ),
+    totalCount: finiteOr(
+      overrideTotal,
+      sumWhere(data, (t) => t >= effectiveRangeStart && t <= end)
+    ),
+    countInLastBucket: finiteOr(
+      overrideCountInLastBucket,
+      sumWhere(data, (t) => t >= lastBucket && t < start)
+    ),
+  };
+}

--- a/webapp/src/lib/client/components/features/charts/events-in-queue-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/events-in-queue-chart-inner.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import * as Chart from "$lib/client/components/ui/chart/index";
+  import { AnnotationLine, AreaChart } from "layerchart";
+  import { scaleTime, scaleLinear } from "d3-scale";
+  import type { DashboardStatsValue } from "$lib/types";
+
+  interface Props {
+    values: DashboardStatsValue[];
+    lastRead: number;
+    /** Start of the current bucket. */
+    start: number;
+    /** End of the query window. */
+    end: number;
+    /** Start of the previous bucket. */
+    lastBucket: number;
+  }
+
+  let { values, lastRead, start, end, lastBucket }: Props = $props();
+
+  // Merge the three datasets into one row-per-timestamp array so a single
+  // AreaChart can render total / current-bucket / previous-bucket as series.
+  // Each bucket series carries the boundary point from the adjacent bucket so
+  // the filled area reaches the transition with no visual gap.
+  type Row = { time: Date; total: number | null; current: number | null; previous: number | null };
+
+  const rows = $derived.by<Row[]>(() => {
+    const sorted = [...values].sort((a, b) => a.time - b.time);
+    const lastBeforeCurrent = sorted.filter((p) => p.time < start).at(-1);
+    const lastBeforePrev = sorted.filter((p) => p.time < lastBucket).at(-1);
+    return sorted.map((p) => {
+      const v = p.value || 0;
+      const inCurrent = p.time >= start && p.time <= end;
+      const inPrev = p.time >= lastBucket && p.time < start;
+      return {
+        time: new Date(p.time),
+        total: v,
+        current: inCurrent || p === lastBeforeCurrent ? v : null,
+        previous: inPrev || p === lastBeforePrev ? v : null,
+      };
+    });
+  });
+
+  const config = {
+    total: { label: "Events In Queue", color: "#3b82f6" },
+    previous: { label: "Previous Bucket", color: "#F47D4A" },
+    current: { label: "Current Bucket", color: "#88a550" },
+  } satisfies Chart.ChartConfig;
+
+  const formatTime = (value: Date | number) =>
+    new Date(value).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+</script>
+
+<Chart.Container {config} class="h-full w-full">
+  <AreaChart
+    data={rows}
+    x="time"
+    xScale={scaleTime()}
+    yScale={scaleLinear()}
+    yNice
+    series={[
+      { key: "total", label: "Events In Queue", color: "#3b82f6" },
+      { key: "previous", label: "Previous Bucket", color: "#F47D4A" },
+      { key: "current", label: "Current Bucket", color: "#88a550" },
+    ]}
+    props={{
+      area: { opacity: 0.5 },
+      xAxis: { format: (v: Date) => formatTime(v), ticks: 10 },
+      yAxis: { format: (v: number) => v.toLocaleString() },
+      grid: { class: "stroke-border/40" },
+    }}
+  >
+    {#snippet aboveMarks()}
+      {#if lastRead}
+        <AnnotationLine x={new Date(lastRead)} props={{ line: { style: "stroke: red; stroke-width: 1;" } }} />
+      {/if}
+    {/snippet}
+    {#snippet tooltip()}
+      <Chart.Tooltip
+        labelFormatter={(_v, payload) =>
+          formatTime((payload?.[0]?.payload as { time?: Date } | undefined)?.time ?? new Date())}
+        hideIndicator
+      />
+    {/snippet}
+  </AreaChart>
+</Chart.Container>

--- a/webapp/src/lib/client/components/features/charts/events-in-queue-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/events-in-queue-chart-inner.svelte
@@ -79,7 +79,14 @@
         labelFormatter={(_v, payload) =>
           formatTime((payload?.[0]?.payload as { time?: Date } | undefined)?.time ?? new Date())}
         hideIndicator
-      />
+      >
+        {#snippet formatter({ value, item })}
+          <!-- Total series only; guard null so gap points don't throw. -->
+          {#if item.key === "total" && value != null}
+            <span>Events In Queue: {(value as number).toLocaleString()}</span>
+          {/if}
+        {/snippet}
+      </Chart.Tooltip>
     {/snippet}
   </AreaChart>
 </Chart.Container>

--- a/webapp/src/lib/client/components/features/charts/events-in-queue-chart.svelte
+++ b/webapp/src/lib/client/components/features/charts/events-in-queue-chart.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
-  import type { Chart, ChartConfiguration } from 'chart.js/auto';
-  import type { DashboardStats, DashboardStatsValue, StatsRange } from '$lib/types';
-  import  annotationPlugin  from 'chartjs-plugin-annotation';
-  import HelpTooltip from '../../help-tooltip.svelte';
-  import { bucketsData, ranges } from '$lib/bucketUtils';
-  import { Separator } from '../../ui/separator';
+  import { browser } from "$app/environment";
+  import type { Component } from "svelte";
+  import type { DashboardStatsValue, StatsRange } from "$lib/types";
+  import HelpTooltip from "../../help-tooltip.svelte";
+  import { bucketsData, ranges } from "$lib/bucketUtils";
+  import { Separator } from "../../ui/separator";
 
   interface Props {
     values: DashboardStatsValue[];
@@ -16,284 +15,63 @@
   }
 
   let { values, lastRead, range, start, end }: Props = $props();
-  let canvas: HTMLCanvasElement;
-  let chart = $state<Chart | null>(null);
-  let totalEvents = $state<number>(0);
-  let eventsInBucket = $state<number>(0);
-  let eventsLastBucket = $state<number>(0);
+
   let rangeData = $derived(ranges[range].rolling ? ranges[range].rolling! : ranges[range]);
   let bucket = $derived(bucketsData[rangeData.period]);
-
   let lastBucket = $derived(bucket.prev(new Date(start), rangeData.count).valueOf());
 
-  // Chart configuration
-  function createChartConfig(): ChartConfiguration<'line'> {
-    return {
-      type: 'line',
-      data: {
-        labels: [],
-        datasets: [{
-          label: 'Events In Queue',
-          data: [],
-          borderColor: '#3b82f6',
-          backgroundColor: 'rgba(163, 165, 153, 0.4)',
-          borderWidth: 2,
-          fill: true,
-          tension: 0.3,
-          pointStyle: false,
-        },
-        {
-          label: 'Current Bucket',
-          data: [],
-          borderColor: '#88a550',
-          backgroundColor: 'rgba(137, 165, 80, 0.6)',
-          borderWidth: 2,
-          fill: true,
-          tension: 0.3,
-          pointStyle: false,
-        },
-        {
-          label: 'Previous Bucket',
-          data: [],
-          borderColor: '#F47D4A',
-          backgroundColor: 'rgba(244, 125, 74, .6)',
-          borderWidth: 2,
-          fill: true,
-          tension: 0.3,
-          pointStyle: false,
-        }
-      ]
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        interaction: {
-          intersect: false,
-          mode: 'nearest'
-        },
-        plugins: {
-          legend: {
-            display: false
-          },
-          tooltip: {
-            backgroundColor: 'rgba(0, 0, 0, 0.8)',
-            titleColor: 'white',
-            bodyColor: 'white',
-            borderColor: '#3b82f6',
-            borderWidth: 1,
-            position: 'nearest',
-            callbacks: {
-              title: function(context) {
-                const timestamp = context[0].parsed.x;
-                return new Date(timestamp).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-              },
-              label: function(context) {
-                if(context.datasetIndex === 0) {
-                  return `Events: ${context.parsed.y.toLocaleString()}`;
-                }
-                // We have to return an empty string here to avoid the tooltip from showing the default label for the other datasets
-                return '';
-              }
-            }
-          },
-          annotation: {
-            annotations: {
-              lastRead: {
-                type: 'line' as const,
-                borderColor: 'red',
-                borderWidth: 1,
-                scaleID: 'x',
-                value: lastRead
-              }
-            }
-          }
-          
-        },
-        scales: {
-          x: {
-            type: 'linear',
-            grid: {
-              color: 'rgba(128, 128, 128, 0.15)'
-            },
-            ticks: {
-              color: '#888888',
-              maxTicksLimit: 10,
-              callback: function(value) {
-                return new Date(value).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-              }
-            }
-          },
-          y: {
-            beginAtZero: true,
-            grid: {
-              color: 'rgba(128, 128, 128, 0.15)'
-            },
-            ticks: {
-              color: '#888888',
-              callback: function(value) {
-                return value.toLocaleString();
-              }
-            }
-          }
-        },
-        elements: {
-          point: {
-            hoverRadius: 4
-          }
-        }
-      }
-    };
-  }
+  const totalEvents = $derived(values.reduce((acc, p) => acc + (p.value || 0), 0));
+  const eventsInBucket = $derived(
+    values.reduce((acc, p) => (p.time >= start ? acc + (p.value || 0) : acc), 0)
+  );
+  const eventsLastBucket = $derived(
+    values.reduce((acc, p) => (p.time >= lastBucket && p.time < start ? acc + (p.value || 0) : acc), 0)
+  );
 
-  // Process data for chart - extract read data from queues
-  function processChartData(dashboardStats: DashboardStats | null): DashboardStatsValue[] {
-    if (!dashboardStats || !dashboardStats.queues) {
-      return [];
-    }
+  // LayerChart renders client-side only; lazy-load the inner chart behind a browser guard.
+  let EventsInQueueChartInner: Component<{
+    values: DashboardStatsValue[];
+    lastRead: number;
+    start: number;
+    end: number;
+    lastBucket: number;
+  }> | null = $state(null);
 
-    // Look for read data in queues
-    const readData: DashboardStatsValue[] = [];
-    
-    // Check if there are any read operations in the queues
-    if (dashboardStats.queues.read) {
-      Object.values(dashboardStats.queues.read).forEach((queueData) => {
-        if (queueData.values && queueData.values.length > 0) {
-          readData.push(...queueData.values);
-        }
+  $effect(() => {
+    if (browser && !EventsInQueueChartInner) {
+      import("./events-in-queue-chart-inner.svelte").then((mod) => {
+        EventsInQueueChartInner = mod.default;
       });
-    }
-
-    // If no read data found, return empty array
-    if (readData.length === 0) {
-        console.log('EventsInQueueChart - no read data found bailing');
-      return [];
-    }
-
-    // Sort by time and return
-    return readData.sort((a, b) => a.time - b.time);
-  }
-
-  // Initialize chart
-  async function initChart() {
-    console.log('EventsInQueueChart - initChart called');
-    if (!canvas) {
-      console.log('EventsInQueueChart - no canvas, returning');
-      return;
-    }
-
-    try {
-      // Import Chart.js dynamically to avoid SSR issues
-      const { Chart } = await import('chart.js/auto');
-      Chart.register(annotationPlugin);
-      
-      const config = createChartConfig();
-      chart = new Chart(canvas, config);
-    } catch (error) {
-      console.error('EventsInQueueChart - Failed to initialize chart:', error);
-    }
-  }
-
-  // Update chart data
-  function updateChart() {
-    if (!chart) {
-      return;
-    }
-
-    const chartData = processChartData(data);
-    eventsInBucket = chartData.reduce((acc, point) => {
-      if(point.time >= start) {
-        acc += (point.value || 0);
-      }
-      return acc;
-    }, 0);
-    totalEvents = chartData.reduce((acc, point) => acc + point.value, 0);
-    eventsLastBucket = chartData.reduce((acc, point) => {
-      if(point.time >= lastBucket && point.time < start) {
-        acc += (point.value || 0);
-      }
-      return acc;
-    }, 0);
-    // Convert to Chart.js format
-    const chartJsData = chartData.map((point: DashboardStatsValue) => ({
-      x: point.time,
-      y: point.value || 0
-    }));
-
-    chart.data.labels = chartData.map((d: DashboardStatsValue) => d.time);
-    chart.data.datasets[0].data = chartJsData;
-    chart.data.datasets[1].data = chartJsData.filter((p) => p.x >= start && p.x <= end);
-    chart.data.datasets[2].data = chartJsData.filter((p) => p.x >= lastBucket && p.x <= start);
-    
-    // Update the annotation with the new lastRead value
-    const annotations = chart.options.plugins?.annotation?.annotations as any;
-    if (annotations?.lastRead) {
-      annotations.lastRead.value = lastRead;
-    }
-    
-    chart.update('active');
-  }
-
-  // Watch for chart and data changes
-  $effect(() => {
-    console.log('EventsInQueueChart - effect triggered - chart:', !!chart, 'data:', !!data);
-    if (chart && data) {
-      console.log('EventsInQueueChart - updating chart');
-      updateChart();
-    }
-  });
-
-  // Watch for lastRead changes specifically
-  $effect(() => {
-    console.log('EventsInQueueChart - lastRead changed to:', lastRead);
-    if (chart) {
-      // Update the annotation when lastRead changes
-      const annotations = chart.options.plugins?.annotation?.annotations as any;
-      if (annotations?.lastRead) {
-        annotations.lastRead.value = lastRead;
-        chart.update('active');
-      }
-    }
-  });
-
-  onMount(() => {
-    console.log('EventsInQueueChart - onMount called');
-    initChart();
-  });
-
-  onDestroy(() => {
-    if (chart) {
-      chart.destroy();
-      chart = null;
     }
   });
 </script>
- <div class="flex flex-col h-full">
-     <h2 class="text-xl font-semibold text-foreground mb-2">Events in Queue</h2>
-     <div class="flex flex-row bg-muted/20 rounded-md w-full h-full overflow-hidden">
-      <div class="p-2 shadow-sm w-1/4 h-full overflow-hidden">
-        <div class="flex flex-col gap-2 justify-between h-full">
-            <div class="flex items-center justify-center gap-2 h-full">
-                <!-- <div class="text-lg font-bold">Total Events</div> -->
-                <div class="text-lg text-blue-500 font-bold">{totalEvents.toLocaleString()}</div>
-                <HelpTooltip helpText="The total number of events in the queue for the time range displayed." help={true}/>
-            </div>
-            <Separator/>
-            <div class="flex items-center justify-center gap-2 h-full">
-              <div class="text-lg text-[#F47D4A] font-bold">{eventsLastBucket.toLocaleString()}</div>
-              <HelpTooltip helpText="The number of events in the last bucket." help={true}/>
-            </div>
-            <Separator/>
-            <div class="flex items-center justify-center gap-2 h-full">
-                <!-- <div class="text-lg font-bold">Events In Last Bucket</div> -->
-                <div class="text-lg text-[#88a550] font-bold">{eventsInBucket.toLocaleString()}</div>
-                <HelpTooltip helpText="The number of events in the current bucket." help={true}/>
-            </div>
-        </div>
-    </div>
-    <Separator orientation="vertical" class="h-full"/>
-         <div class="p-2 shadow-sm w-3/4 h-full overflow-hidden">
-           <canvas bind:this={canvas} class="w-full h-full max-w-full max-h-full"></canvas>
-         </div>
-     </div>
- </div>
 
+<div class="flex flex-col h-full">
+  <h2 class="text-xl font-semibold text-foreground mb-2">Events in Queue</h2>
+  <div class="flex flex-row bg-muted/20 rounded-md w-full h-full overflow-hidden">
+    <div class="p-2 shadow-sm w-1/4 h-full overflow-hidden">
+      <div class="flex flex-col gap-2 justify-between h-full">
+        <div class="flex items-center justify-center gap-2 h-full">
+          <div class="text-lg text-blue-500 font-bold">{totalEvents.toLocaleString()}</div>
+          <HelpTooltip helpText="The total number of events in the queue for the time range displayed." help={true} />
+        </div>
+        <Separator />
+        <div class="flex items-center justify-center gap-2 h-full">
+          <div class="text-lg text-[#F47D4A] font-bold">{eventsLastBucket.toLocaleString()}</div>
+          <HelpTooltip helpText="The number of events in the last bucket." help={true} />
+        </div>
+        <Separator />
+        <div class="flex items-center justify-center gap-2 h-full">
+          <div class="text-lg text-[#88a550] font-bold">{eventsInBucket.toLocaleString()}</div>
+          <HelpTooltip helpText="The number of events in the current bucket." help={true} />
+        </div>
+      </div>
+    </div>
+    <Separator orientation="vertical" class="h-full" />
+    <div class="p-2 shadow-sm w-3/4 h-full overflow-hidden">
+      {#if EventsInQueueChartInner}
+        <EventsInQueueChartInner {values} {lastRead} {start} {end} {lastBucket} />
+      {/if}
+    </div>
+  </div>
+</div>

--- a/webapp/src/lib/client/components/features/charts/events-read-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/events-read-chart-inner.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import * as Chart from "$lib/client/components/ui/chart/index";
+  import { LineChart } from "layerchart";
+  import { scaleTime, scaleLinear } from "d3-scale";
+  import type { DashboardStatsValue } from "$lib/types";
+
+  interface Props {
+    chartData: DashboardStatsValue[];
+  }
+
+  let { chartData }: Props = $props();
+
+  const rows = $derived(chartData.map((d) => ({ time: new Date(d.time), value: d.value || 0 })));
+
+  const config = $derived({
+    value: { label: "Events Read", color: "#3b82f6" },
+  } satisfies Chart.ChartConfig);
+
+  const formatTime = (value: Date | number) =>
+    new Date(value).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+</script>
+
+<Chart.Container {config} class="h-full w-full">
+  <LineChart
+    data={rows}
+    x="time"
+    xScale={scaleTime()}
+    y="value"
+    yScale={scaleLinear()}
+    yNice
+    series={[{ key: "value", label: "Events Read", color: "#3b82f6" }]}
+    props={{
+      spline: { class: "stroke-2" },
+      xAxis: { format: (v: Date) => formatTime(v), ticks: 10 },
+      yAxis: { format: (v: number) => v.toLocaleString() },
+      grid: { class: "stroke-border/40" },
+    }}
+  >
+    {#snippet tooltip()}
+      <Chart.Tooltip
+        labelFormatter={(_v, payload) =>
+          formatTime((payload?.[0]?.payload as { time?: Date } | undefined)?.time ?? new Date())}
+        hideIndicator
+      >
+        {#snippet formatter({ value })}
+          <span>Events: {(value as number).toLocaleString()}</span>
+        {/snippet}
+      </Chart.Tooltip>
+    {/snippet}
+  </LineChart>
+</Chart.Container>

--- a/webapp/src/lib/client/components/features/charts/events-read-chart.svelte
+++ b/webapp/src/lib/client/components/features/charts/events-read-chart.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
+  import { browser } from "$app/environment";
+  import type { Component } from "svelte";
   import type { DashboardStats, DashboardStatsValue, StatsRange } from "$lib/types";
-  import type { ChartConfiguration, Chart } from "chart.js/auto";
-  import { onDestroy, onMount } from "svelte";
   import { Separator } from "../../ui/separator";
-  import { bucketsData, getStartAndEndOfBucket, ranges } from "$lib/bucketUtils";
   import HelpTooltip from "../../help-tooltip.svelte";
 
   interface Props {
@@ -14,202 +13,46 @@
     end: number;
   }
 
-  let { data, queueId, range, start, end }: Props = $props();
+  let { data, queueId, start }: Props = $props();
 
-  let canvas: HTMLCanvasElement;
-  let chart = $state<Chart | null>(null);
-  let eventsReadInBucket = $state<number>(0);
-  let lastDataHash = $state<string>('');
-
-  let rangeData = $derived(ranges[range].rolling ? ranges[range].rolling! : ranges[range]);
-  let bucket = $derived(bucketsData[rangeData.period]);
-
-  let lastBucket = $derived(bucket.prev(new Date(start), rangeData.count).valueOf());
-
-  function createChartConfig(): ChartConfiguration<"line"> {
-    return {
-      type: "line",
-      data: {
-        labels: [],
-        datasets: [
-          {
-            label: "Events Read",
-            data: [],
-            borderColor: "#3b82f6",
-            backgroundColor: "rgba(59, 130, 246, 0.1)",
-            borderWidth: 2,
-            fill: false,
-            tension: 0.1,
-            pointStyle: false,
-          },
-        ],
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        interaction: {
-          intersect: false,
-          mode: 'index'
-        },
-        plugins: {
-          legend: {
-            display: false
-          },
-          tooltip: {
-            backgroundColor: 'rgba(0, 0, 0, 0.8)',
-            titleColor: 'white',
-            bodyColor: 'white',
-            borderColor: '#3b82f6',
-            borderWidth: 1,
-            callbacks: {
-              title: function(context) {
-                const timestamp = context[0].parsed.x;
-                return new Date(timestamp).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-              },
-              label: function(context) {
-                return `Events: ${context.parsed.y.toLocaleString()}`;
-              }
-            }
-          },
-        },
-        scales: {
-          x: {
-            type: 'linear',
-            grid: {
-              color: 'rgba(128, 128, 128, 0.15)'
-            },
-            ticks: {
-              color: '#888888',
-              maxTicksLimit: 10,
-              callback: function(value) {
-                return new Date(value).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-              }
-            },
-            offset: false,
-          },
-          y: {
-            type: 'linear',
-            beginAtZero: true,
-            grid: {
-              color: 'rgba(128, 128, 128, 0.15)'
-            },
-            ticks: {
-              color: '#888888',
-              callback: function(value) {
-                return value.toLocaleString();
-              }
-            }
-          }
-        },
-      },
-    };
-  }
-
-  function processChartData(dashboardStats: DashboardStats | null): { chartData: DashboardStatsValue[], bucketCount: number } {
-    if (!dashboardStats || !dashboardStats.queues) {
-      return { chartData: [], bucketCount: 0 };
-    }
-
-    console.log('start', start);
-    console.log('end', end);
-
-    const eventsRead: DashboardStatsValue[] = [];
+  const processed = $derived.by(() => {
+    const reads = data?.queues?.read?.[queueId]?.reads;
+    if (!reads) return { chartData: [] as DashboardStatsValue[], bucketCount: 0 };
     let bucketCount = 0;
-
-    if(dashboardStats.queues.read && dashboardStats.queues.read[queueId] && dashboardStats.queues.read[queueId].reads) {
-        for (const readValue of dashboardStats.queues.read[queueId].reads) {
-            eventsRead.push(readValue);
-            if(readValue.time >= start) {
-                bucketCount += readValue.value;
-            }
-        }
+    for (const r of reads) {
+      if (r.time >= start) bucketCount += r.value;
     }
+    return { chartData: [...reads].sort((a, b) => a.time - b.time), bucketCount };
+  });
 
-    return { 
-      chartData: eventsRead.sort((a, b) => a.time - b.time),
-      bucketCount 
-    };
-  }
-
-  async function initChart() {
-    try {
-        const { Chart } = await import('chart.js/auto');
-        if(!canvas) {
-            return;
-        }
-
-        chart = new Chart(canvas, createChartConfig());
-    } catch (error) {
-        console.error('Error initializing chart:', error);
-    }
-  }
-
-  function updateChart() {
-    if(!chart) {
-        return;
-    }
-
-    const { chartData, bucketCount } = processChartData(data);
-    
-    // Update chart data
-    chart.data.labels = chartData.map((d: DashboardStatsValue) => d.time);
-    chart.data.datasets[0].data = chartData.map((d: DashboardStatsValue) => d.value || 0);
-    chart.update('active');
-    
-    // Update bucket count
-    eventsReadInBucket = bucketCount;
-  }
+  // LayerChart renders client-side only; lazy-load the inner chart behind a browser guard.
+  let EventsReadChartInner: Component<{ chartData: DashboardStatsValue[] }> | null = $state(null);
 
   $effect(() => {
-    if(chart && data) {
-      // Create a hash of the data to check if it actually changed
-      const dataHash = JSON.stringify({ data, queueId, range });
-      if (dataHash !== lastDataHash) {
-        lastDataHash = dataHash;
-        updateChart();
-      }
-    }
-  });
-
-  onMount(() => {
-    initChart();
-  });
-
-  onDestroy(() => {
-    if(chart) {
-      chart.destroy();
-      chart = null;
+    if (browser && !EventsReadChartInner) {
+      import("./events-read-chart-inner.svelte").then((mod) => {
+        EventsReadChartInner = mod.default;
+      });
     }
   });
 </script>
 
 <div class="flex flex-col h-full">
-    <h2 class="text-xl font-semibold text-foreground mb-2">Events Read</h2>
-    <div class="flex flex-row bg-muted/20 rounded-md w-full h-full overflow-hidden">
-        <div class="p-2 shadow-sm w-1/4 h-full overflow-hidden">
-            <div class="flex flex-col gap-2 justify-between h-full">
-                <div class="flex items-center justify-center gap-2 h-full">
-                    <div class="text-lg font-bold">{eventsReadInBucket}</div>
-                    <HelpTooltip helpText="The number of events read from the queue in the current time bucket." info={true}/>
-                </div>
-            </div>
-            <!-- <div class="flex flex-col gap-2 justify-between h-full">
-                <div class="flex items-center justify-center gap-2 h-full">
-                    <div class="text-lg font-bold">Source Lag</div>
-                    <div class="text-lg text-blue-500 font-bold">{humanize(currentSourceLag)}</div>
-                    <HelpTooltip helpText="The lag between the source and the queue." help={true}/>
-                </div>
-                <Separator/>
-                <div class="flex items-center justify-center gap-2 h-full">
-                    <div class="text-lg font-bold">Queue Lag</div>
-                    <div class="text-lg text-red-500 font-bold">{humanize(currentQueueLag)}</div>
-                    <HelpTooltip helpText="The lag within the queue processing." help={true}/>
-                </div>
-            </div> -->
+  <h2 class="text-xl font-semibold text-foreground mb-2">Events Read</h2>
+  <div class="flex flex-row bg-muted/20 rounded-md w-full h-full overflow-hidden">
+    <div class="p-2 shadow-sm w-1/4 h-full overflow-hidden">
+      <div class="flex flex-col gap-2 justify-between h-full">
+        <div class="flex items-center justify-center gap-2 h-full">
+          <div class="text-lg font-bold">{processed.bucketCount}</div>
+          <HelpTooltip helpText="The number of events read from the queue in the current time bucket." info={true} />
         </div>
-        <Separator orientation="vertical" class="h-full"/>
-        <div class="p-2 shadow-sm w-3/4 h-full overflow-hidden">
-          <canvas bind:this={canvas} class="w-full h-full max-w-full max-h-full"></canvas>
-        </div>
+      </div>
     </div>
+    <Separator orientation="vertical" class="h-full" />
+    <div class="p-2 shadow-sm w-3/4 h-full overflow-hidden">
+      {#if EventsReadChartInner}
+        <EventsReadChartInner chartData={processed.chartData} />
+      {/if}
+    </div>
+  </div>
 </div>

--- a/webapp/src/lib/client/components/features/charts/generic-bucket-line-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/generic-bucket-line-chart-inner.svelte
@@ -4,7 +4,7 @@
   import { scaleTime, scaleLinear, scaleLog } from "d3-scale";
   import { onMount } from "svelte";
   import type { DashboardStatsValue } from "$lib/types";
-  import { chartYBaseline, logSafe } from "./y-axis";
+  import { chartYBaseline, logClamp, logFloor } from "./y-axis";
 
   interface Props {
     data: DashboardStatsValue[];
@@ -43,8 +43,9 @@
     const sorted = [...data].sort((a, b) => a.time - b.time);
     const lastBeforeCurrent = sorted.filter((p) => p.time < start).at(-1);
     const lastBeforePrev = sorted.filter((p) => p.time < lastBucket).at(-1);
+    const floor = logFloor(sorted.map((p) => p.value));
     return sorted.map((p) => {
-      const v = logSafe(p.value || 0, showLogarithmic);
+      const v = logClamp(p.value || 0, showLogarithmic, floor);
       const inCurrent = p.time >= start && p.time <= end;
       const inPrev = p.time >= lastBucket && p.time < start;
       return {

--- a/webapp/src/lib/client/components/features/charts/generic-bucket-line-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/generic-bucket-line-chart-inner.svelte
@@ -4,7 +4,7 @@
   import { scaleTime, scaleLinear, scaleLog } from "d3-scale";
   import { onMount } from "svelte";
   import type { DashboardStatsValue } from "$lib/types";
-  import { chartYBaseline } from "./y-axis";
+  import { chartYBaseline, logSafe } from "./y-axis";
 
   interface Props {
     data: DashboardStatsValue[];
@@ -44,7 +44,7 @@
     const lastBeforeCurrent = sorted.filter((p) => p.time < start).at(-1);
     const lastBeforePrev = sorted.filter((p) => p.time < lastBucket).at(-1);
     return sorted.map((p) => {
-      const v = p.value || 0;
+      const v = logSafe(p.value || 0, showLogarithmic);
       const inCurrent = p.time >= start && p.time <= end;
       const inPrev = p.time >= lastBucket && p.time < start;
       return {
@@ -114,7 +114,17 @@
         labelFormatter={(_v, payload) =>
           formatTime((payload?.[0]?.payload as { time?: Date } | undefined)?.time ?? new Date())}
         hideIndicator
-      />
+      >
+        {#snippet formatter({ value, item })}
+          <!-- Show only the "total" series (like the prior Chart.js tooltip, which
+               returned "" for the current/previous datasets). Guard null so gap
+               points — including non-positive values dropped on a log axis — don't
+               throw on `null.toLocaleString()`. -->
+          {#if item.key === "total" && value != null}
+            <span>{chartLabel}: {formatValue(value as number)}</span>
+          {/if}
+        {/snippet}
+      </Chart.Tooltip>
     {/snippet}
   </AreaChart>
 </Chart.Container>

--- a/webapp/src/lib/client/components/features/charts/generic-bucket-line-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/generic-bucket-line-chart-inner.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import * as Chart from "$lib/client/components/ui/chart/index";
+  import { AnnotationLine, AreaChart } from "layerchart";
+  import { scaleTime, scaleLinear, scaleLog } from "d3-scale";
+  import { onMount } from "svelte";
+  import type { DashboardStatsValue } from "$lib/types";
+
+  interface Props {
+    data: DashboardStatsValue[];
+    chartLabel: string;
+    /** Start of the current stats bucket. */
+    start: number;
+    /** End of the query window. */
+    end: number;
+    /** Start of the previous bucket. */
+    lastBucket: number;
+    /** Start of the query window (aligned with API stats window). */
+    rangeStart: number;
+    checkPointValue?: number;
+    showLogarithmic?: boolean;
+  }
+
+  let { data, chartLabel, start, end, lastBucket, rangeStart, checkPointValue, showLogarithmic = false }: Props = $props();
+
+  /** If wall clock is far past the query end, don't stretch the x-axis to "now". */
+  const STALE_QUERY_MS = 90_000;
+
+  // Refresh the "now" line periodically while mounted (matches prior Chart.js behavior).
+  let now = $state(new Date());
+  onMount(() => {
+    const id = setInterval(() => (now = new Date()), 30_000);
+    return () => clearInterval(id);
+  });
+
+  // Merge the three datasets into one row-per-timestamp array so a single
+  // AreaChart can render total / current-bucket / previous-bucket as series.
+  // Each bucket series carries the boundary point from the adjacent bucket so
+  // the filled area reaches the transition with no visual gap.
+  type Row = { time: Date; total: number | null; current: number | null; previous: number | null };
+
+  const rows = $derived.by<Row[]>(() => {
+    const sorted = [...data].sort((a, b) => a.time - b.time);
+    const lastBeforeCurrent = sorted.filter((p) => p.time < start).at(-1);
+    const lastBeforePrev = sorted.filter((p) => p.time < lastBucket).at(-1);
+    return sorted.map((p) => {
+      const v = p.value || 0;
+      const inCurrent = p.time >= start && p.time <= end;
+      const inPrev = p.time >= lastBucket && p.time < start;
+      return {
+        time: new Date(p.time),
+        total: v,
+        current: inCurrent || p === lastBeforeCurrent ? v : null,
+        previous: inPrev || p === lastBeforePrev ? v : null,
+      };
+    });
+  });
+
+  const queryStale = $derived(now.getTime() > end + STALE_QUERY_MS);
+
+  const xDomain = $derived.by(() => {
+    if (!data.length) return undefined;
+    const times = data.map((d) => d.time);
+    const minMs = Math.min(...times, rangeStart, lastBucket, start);
+    const maxMs = queryStale ? Math.max(...times, end) : Math.max(...times, end, now.getTime());
+    return [new Date(minMs), new Date(maxMs)] as [Date, Date];
+  });
+
+  const config = $derived({
+    total: { label: chartLabel, color: "#3b82f6" },
+    previous: { label: "Previous Bucket", color: "#F47D4A" },
+    current: { label: "Current Bucket", color: "#88a550" },
+  } satisfies Chart.ChartConfig);
+
+  const formatTime = (value: Date | number) =>
+    new Date(value).toLocaleTimeString(undefined, { hourCycle: "h23", hour: "2-digit", minute: "2-digit" });
+  const formatValue = (value: number) => value.toLocaleString();
+</script>
+
+<Chart.Container {config} class="h-full w-full">
+  <AreaChart
+    data={rows}
+    x="time"
+    xScale={scaleTime()}
+    {xDomain}
+    yScale={showLogarithmic ? scaleLog() : scaleLinear()}
+    yNice
+    series={[
+      { key: "total", label: chartLabel, color: "#3b82f6" },
+      { key: "previous", label: "Previous Bucket", color: "#F47D4A" },
+      { key: "current", label: "Current Bucket", color: "#88a550" },
+    ]}
+    props={{
+      area: { opacity: 0.5 },
+      xAxis: { format: (v: Date) => formatTime(v), ticks: 7 },
+      yAxis: { format: (v: number) => formatValue(v) },
+      grid: { class: "stroke-border/40" },
+    }}
+  >
+    {#snippet aboveMarks()}
+      {#if !queryStale}
+        <AnnotationLine x={now} props={{ line: { style: "stroke: rgba(239, 68, 68, 0.95); stroke-width: 2;" } }} />
+      {/if}
+      {#if checkPointValue != null && Number.isFinite(checkPointValue)}
+        <AnnotationLine
+          x={new Date(checkPointValue)}
+          props={{ line: { style: "stroke: rgba(248, 113, 113, 0.7); stroke-width: 1; stroke-dasharray: 4 4;" } }}
+        />
+      {/if}
+    {/snippet}
+    {#snippet tooltip()}
+      <Chart.Tooltip
+        labelFormatter={(_v, payload) =>
+          formatTime((payload?.[0]?.payload as { time?: Date } | undefined)?.time ?? new Date())}
+        hideIndicator
+      />
+    {/snippet}
+  </AreaChart>
+</Chart.Container>

--- a/webapp/src/lib/client/components/features/charts/generic-bucket-line-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/generic-bucket-line-chart-inner.svelte
@@ -4,6 +4,7 @@
   import { scaleTime, scaleLinear, scaleLog } from "d3-scale";
   import { onMount } from "svelte";
   import type { DashboardStatsValue } from "$lib/types";
+  import { chartYBaseline } from "./y-axis";
 
   interface Props {
     data: DashboardStatsValue[];
@@ -84,6 +85,7 @@
     {xDomain}
     yScale={showLogarithmic ? scaleLog() : scaleLinear()}
     yNice
+    yBaseline={chartYBaseline(showLogarithmic)}
     series={[
       { key: "total", label: chartLabel, color: "#3b82f6" },
       { key: "previous", label: "Previous Bucket", color: "#F47D4A" },

--- a/webapp/src/lib/client/components/features/charts/generic-bucket-line-chart.svelte
+++ b/webapp/src/lib/client/components/features/charts/generic-bucket-line-chart.svelte
@@ -2,6 +2,7 @@
   import { browser } from "$app/environment";
   import type { Component } from "svelte";
   import { bucketsData, ranges } from "$lib/bucketUtils";
+  import { computeBucketTotals } from "./bucket-totals";
   import type { DashboardStatsValue, StatsRange } from "$lib/types";
   import HelpTooltip from "../../help-tooltip.svelte";
   import { Separator } from "../../ui/separator";
@@ -71,30 +72,23 @@
 
   let showLogarithmic = $state<boolean>(false);
 
-  const finiteOr = (n: number | undefined, fallback: number) =>
-    typeof n === "number" && Number.isFinite(n) ? n : fallback;
-
-  const countInBucket = $derived(
-    finiteOr(
-      overrideCountInBucket,
-      (data ?? []).reduce((acc, p) => (p.time >= start && p.time <= end ? acc + (Number(p.value) || 0) : acc), 0)
-    )
-  );
-  const totalCount = $derived(
-    finiteOr(
+  // Aggregation for the three "total" rows. Lib-agnostic and unit-tested in
+  // bucket-totals.test.ts (ES-3031) so the migration can't silently change the numbers.
+  const totals = $derived(
+    computeBucketTotals({
+      data,
+      start,
+      end,
+      effectiveRangeStart,
+      lastBucket,
       overrideTotal,
-      (data ?? []).reduce(
-        (acc, p) => (p.time >= effectiveRangeStart && p.time <= end ? acc + (Number(p.value) || 0) : acc),
-        0
-      )
-    )
-  );
-  const countInLastBucket = $derived(
-    finiteOr(
+      overrideCountInBucket,
       overrideCountInLastBucket,
-      (data ?? []).reduce((acc, p) => (p.time >= lastBucket && p.time < start ? acc + (Number(p.value) || 0) : acc), 0)
-    )
+    })
   );
+  const countInBucket = $derived(totals.countInBucket);
+  const totalCount = $derived(totals.totalCount);
+  const countInLastBucket = $derived(totals.countInLastBucket);
 
   // LayerChart renders client-side only; lazy-load the inner chart behind a browser guard.
   let GenericBucketLineChartInner: Component<{

--- a/webapp/src/lib/client/components/features/charts/generic-bucket-line-chart.svelte
+++ b/webapp/src/lib/client/components/features/charts/generic-bucket-line-chart.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
+  import { browser } from "$app/environment";
+  import type { Component } from "svelte";
   import { bucketsData, ranges } from "$lib/bucketUtils";
   import type { DashboardStatsValue, StatsRange } from "$lib/types";
-  import  annotationPlugin  from 'chartjs-plugin-annotation';
-  import type { ChartConfiguration } from "chart.js/auto";
-  import type Chart from "chart.js/auto";
-  import { onDestroy, onMount } from "svelte";
   import HelpTooltip from "../../help-tooltip.svelte";
   import { Separator } from "../../ui/separator";
-  import { Label } from "../../ui/label";
-  import { Switch } from "../../ui/switch";
   import type { ChartOptions } from "../chart-details-pane/types";
   import ChartOptionsMenu from "./chart-options.svelte";
 
@@ -50,12 +46,7 @@
     overrideCountInBucket,
     showTitle = true,
   }: Props = $props();
-  let canvas: HTMLCanvasElement;
-  let chart = $state<Chart | null>(null);
 
-  let totalCount = $state<number>(0);
-  let countInBucket = $state<number>(0);
-  let countInLastBucket = $state<number>(0);
   let rangeData = $derived(
     ranges[range].rolling ? ranges[range].rolling! : ranges[range]
   );
@@ -70,399 +61,117 @@
   let effectiveRangeStart = $derived(
     rangeStartProp != null && Number.isFinite(rangeStartProp) ? rangeStartProp : queueStartBucket
   );
-  let humanRangeStart = $derived(
-    new Date(effectiveRangeStart).toLocaleTimeString(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-    })
-  );
 
-  let humanStart = $derived(new Date(start).toLocaleTimeString(undefined, {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                }));
-  let humanEnd = $derived(new Date(end).toLocaleTimeString(undefined, {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                }));
-  let humanLastBucket = $derived(new Date(lastBucket).toLocaleTimeString(undefined, {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                }));
+  let humanRangeStart = $derived(
+    new Date(effectiveRangeStart).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })
+  );
+  let humanStart = $derived(new Date(start).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" }));
+  let humanEnd = $derived(new Date(end).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" }));
+  let humanLastBucket = $derived(new Date(lastBucket).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" }));
+
   let showLogarithmic = $state<boolean>(false);
 
-  /** Refresh “now” line periodically while the chart is mounted */
-  let nowRefreshInterval: ReturnType<typeof setInterval> | null = null;
+  const finiteOr = (n: number | undefined, fallback: number) =>
+    typeof n === "number" && Number.isFinite(n) ? n : fallback;
 
-  /** If wall clock is far past API query end, don’t stretch the x-axis to “now” (avoids a huge empty gap when stats haven’t been refetched). */
-  const STALE_QUERY_MS = 90_000;
-
-  // Chart configuration
-  function createChartConfig(): ChartConfiguration<"line"> {
-    return {
-      type: "line",
-      data: {
-        labels: [],
-        datasets: [
-          {
-            label: chartLabel,
-            data: [],
-            borderColor: "#3b82f6",
-            backgroundColor: "rgba(163, 165, 153, 0.4)",
-            borderWidth: 2,
-            fill: true,
-            tension: 0.1,
-            pointStyle: false,
-          },
-          {
-            label: "Current Bucket",
-            data: [],
-            borderColor: "#88a550",
-            backgroundColor: "rgba(137, 165, 80, 0.6)",
-            borderWidth: 2,
-            fill: true,
-            tension: 0.1,
-            pointStyle: false,
-          },
-          {
-            label: "Previous Bucket",
-            data: [],
-            borderColor: "#F47D4A",
-            backgroundColor: "rgba(244, 125, 74, .6)",
-            borderWidth: 2,
-            fill: true,
-            tension: 0.1,
-            pointStyle: false,
-          },
-        ],
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        interaction: {
-          intersect: false,
-          mode: "nearest",
-        },
-        plugins: {
-          legend: {
-            display: false,
-          },
-          tooltip: {
-            backgroundColor: "rgba(0, 0, 0, 0.8)",
-            titleColor: "white",
-            bodyColor: "white",
-            borderColor: "#3b82f6",
-            borderWidth: 1,
-            position: "nearest",
-            callbacks: {
-              title: function (context) {
-                const timestamp = context[0].parsed.x;
-                return new Date(timestamp).toLocaleTimeString(undefined, {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                });
-              },
-              label: function (context) {
-                if (context.datasetIndex === 0) {
-                  return `Events: ${context.parsed.y.toLocaleString()}`;
-                }
-                // We have to return an empty string here to avoid the tooltip from showing the default label for the other datasets
-                return "";
-              },
-            },
-          },
-          //   annotation: {
-          //     annotations: {
-          //       lastRead: {
-          //         type: 'line' as const,
-          //         borderColor: 'red',
-          //         borderWidth: 1,
-          //         scaleID: 'x',
-          //         value: lastRead
-          //       }
-          //     }
-          //   }
-        },
-        scales: {
-          x: {
-            bounds: 'data',
-            type: "linear",
-            // grid: {
-            //   color: "rgba(128, 128, 128, 0.15)",
-            // },
-            ticks: {
-              color: "#888888",
-              maxTicksLimit: 7,
-              callback: function (value) {
-                return new Date(value).toLocaleTimeString(undefined, {
-                  hourCycle: "h23",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                });
-              },
-              minRotation: 50,
-              maxRotation: 60,
-            },
-          },
-          y: {
-            type: 'linear',
-            grid: {
-              color: "rgba(128, 128, 128, 0.15)",
-            },
-            ticks: {
-              color: "#888888",
-              callback: function (value) {
-                return value.toLocaleString();
-              },
-            },
-          },
-        },
-      },
-    };
-  }
-
-  async function initChart() {
-    if (!canvas) {
-      return;
-    }
-
-    try {
-      // Import Chart.js dynamically to avoid SSR issues
-      const { Chart } = await import('chart.js/auto');
-      Chart.register(annotationPlugin);
-      
-      const config = createChartConfig();
-      chart = new Chart(canvas, config);
-    } catch (error) {
-      console.error('Failed to initialize chart:', error);
-    }
-  }
-
-  function updateChart() {
-    if (!chart || !data) {
-      return;
-    }
-
-    
-    const finiteOr = (n: number | undefined, fallback: number) =>
-      typeof n === "number" && Number.isFinite(n) ? n : fallback;
-
-    const rangeLo = effectiveRangeStart;
-    const rangeHi = end;
-
-    countInBucket = finiteOr(
+  const countInBucket = $derived(
+    finiteOr(
       overrideCountInBucket,
-      data.reduce((acc, point) => {
-        if (point.time >= start && point.time <= rangeHi) {
-          acc += Number(point.value) || 0;
-        }
-        return acc;
-      }, 0)
-    );
-    totalCount = finiteOr(
+      (data ?? []).reduce((acc, p) => (p.time >= start && p.time <= end ? acc + (Number(p.value) || 0) : acc), 0)
+    )
+  );
+  const totalCount = $derived(
+    finiteOr(
       overrideTotal,
-      data.reduce((acc, point) => {
-        if (point.time >= rangeLo && point.time <= rangeHi) {
-          acc += Number(point.value) || 0;
-        }
-        return acc;
-      }, 0)
-    );
-    countInLastBucket = finiteOr(
+      (data ?? []).reduce(
+        (acc, p) => (p.time >= effectiveRangeStart && p.time <= end ? acc + (Number(p.value) || 0) : acc),
+        0
+      )
+    )
+  );
+  const countInLastBucket = $derived(
+    finiteOr(
       overrideCountInLastBucket,
-      data.reduce((acc, point) => {
-        if (point.time >= lastBucket && point.time < start) {
-          acc += Number(point.value) || 0;
-        }
-        return acc;
-      }, 0)
-    );
-    // Convert to Chart.js format
-    const chartJsData = data.map((point: DashboardStatsValue) => ({
-      x: point.time,
-      y: point.value || 0
-    }));
+      (data ?? []).reduce((acc, p) => (p.time >= lastBucket && p.time < start ? acc + (Number(p.value) || 0) : acc), 0)
+    )
+  );
 
-    chart.data.labels = data.map((d: DashboardStatsValue) => d.time);
-    chart.data.datasets[0].data = chartJsData;
+  // LayerChart renders client-side only; lazy-load the inner chart behind a browser guard.
+  let GenericBucketLineChartInner: Component<{
+    data: DashboardStatsValue[];
+    chartLabel: string;
+    start: number;
+    end: number;
+    lastBucket: number;
+    rangeStart: number;
+    checkPointValue?: number;
+    showLogarithmic?: boolean;
+  }> | null = $state(null);
 
-    // Each bucket dataset includes the boundary point from the adjacent bucket
-    // so the filled area reaches the transition — no visual gaps.
-    // Previous bucket extends back to include last point before lastBucket.
-    // Current bucket extends back to include last point before start.
-    // No double-overlap: previous stops strictly before start.
-    const sorted = [...chartJsData].sort((a, b) => a.x - b.x);
-
-    const lastBeforeCurrent = sorted.filter((p) => p.x < start).pop();
-    const currentPoints = sorted.filter((p) => p.x >= start && p.x <= end);
-    if (lastBeforeCurrent) currentPoints.unshift(lastBeforeCurrent);
-    chart.data.datasets[1].data = currentPoints;
-
-    const lastBeforePrev = sorted.filter((p) => p.x < lastBucket).pop();
-    const prevPoints = sorted.filter((p) => p.x >= lastBucket && p.x < start);
-    if (lastBeforePrev) prevPoints.unshift(lastBeforePrev);
-    chart.data.datasets[2].data = prevPoints;
-
-    const nowMs = Date.now();
-    const xScale = chart.options.scales!.x as { min?: number; max?: number };
-    const annos: Record<string, unknown> = {};
-    const queryStale = nowMs > rangeHi + STALE_QUERY_MS;
-
-    if (chartJsData.length > 0) {
-      const times = chartJsData.map((p) => p.x);
-      // X domain: full query window + data. Extend to “now” only while the loaded snapshot is still fresh.
-      xScale.min = Math.min(...times, rangeLo, lastBucket, start);
-      xScale.max = queryStale
-        ? Math.max(...times, rangeHi)
-        : Math.max(...times, rangeHi, nowMs);
-      if (!queryStale) {
-        annos.nowLine = {
-          type: "line",
-          scaleID: "x",
-          value: nowMs,
-          borderColor: "rgba(239, 68, 68, 0.95)",
-          borderWidth: 2,
-        };
-      }
-      if (checkPointValue != null && Number.isFinite(checkPointValue)) {
-        annos.checkPointValue = {
-          type: "line",
-          borderColor: "rgba(248, 113, 113, 0.7)",
-          borderWidth: 1,
-          borderDash: [4, 4],
-          scaleID: "x",
-          value: checkPointValue,
-        };
-      }
-    } else {
-      delete xScale.min;
-      delete xScale.max;
-    }
-
-    chart.options.plugins!.annotation = { annotations: annos as any };
-
-    chart.options!.scales!.y!.type = showLogarithmic ? 'logarithmic' : 'linear';
-    chart.update('active');
-  }
-
-  // Re-run when stats refresh updates API bucket boundaries (start/end/currentBucketStart) even if `data` identity is unchanged.
   $effect(() => {
-    if (!chart || !data) return;
-    void start;
-    void end;
-    void range;
-    void rangeStartProp;
-    void lastBucket;
-    void effectiveRangeStart;
-    void checkPointValue;
-    void overrideTotal;
-    void overrideCountInBucket;
-    void overrideCountInLastBucket;
-    void showLogarithmic;
-    setTimeout(() => {
-      updateChart();
-    }, 0);
-  });
-
-  function refreshNowLine() {
-    if (!chart?.options?.plugins?.annotation) return;
-    const annos = chart.options.plugins.annotation.annotations as Record<string, any>;
-    const nowMs = Date.now();
-    const xScale = chart.options.scales!.x as { min?: number; max?: number };
-    const rangeHi = end;
-    const queryStale = nowMs > rangeHi + STALE_QUERY_MS;
-
-    if (queryStale) {
-      if (annos?.nowLine) delete annos.nowLine;
-      const ds0 = chart.data.datasets[0]?.data as { x: number }[] | undefined;
-      const times = ds0?.map((p) => p.x) ?? [];
-      if (times.length > 0 && Number.isFinite(rangeHi)) {
-        xScale.max = Math.max(...times, rangeHi);
-      }
-      chart.update("none");
-      return;
-    }
-
-    if (!annos?.nowLine) {
-      annos.nowLine = {
-        type: "line",
-        scaleID: "x",
-        value: nowMs,
-        borderColor: "rgba(239, 68, 68, 0.95)",
-        borderWidth: 2,
-      };
-    } else {
-      annos.nowLine.value = nowMs;
-    }
-    if (typeof xScale.max === "number" && nowMs > xScale.max) {
-      xScale.max = nowMs;
-    }
-    chart.update("none");
-  }
-
-  onMount(() => {
-    initChart();
-    nowRefreshInterval = setInterval(refreshNowLine, 30_000);
-  });
-
-  onDestroy(() => {
-    if (nowRefreshInterval) {
-      clearInterval(nowRefreshInterval);
-      nowRefreshInterval = null;
-    }
-    if (chart) {
-      chart.destroy();
-      chart = null;
+    if (browser && !GenericBucketLineChartInner) {
+      import("./generic-bucket-line-chart-inner.svelte").then((mod) => {
+        GenericBucketLineChartInner = mod.default;
+      });
     }
   });
 </script>
 
 <div class="flex flex-col h-full">
-    {#if showTitle || chartOptions}
+  {#if showTitle || chartOptions}
     <div class="flex flex-row justify-between">
       {#if showTitle}
-      <h2 class="text-xl font-semibold text-foreground mb-2">{chartLabel}</h2>
+        <h2 class="text-xl font-semibold text-foreground mb-2">{chartLabel}</h2>
       {:else}
-      <div></div>
+        <div></div>
       {/if}
       {#if chartOptions}
         <ChartOptionsMenu chartOptions={chartOptions} bind:logSwitch={showLogarithmic} />
       {/if}
     </div>
-    {/if}
-    <div class="flex flex-row bg-muted/20 rounded-md w-full h-full overflow-hidden">
-     <div class="p-2 shadow-sm w-1/4 h-full overflow-hidden">
-       <div class="flex flex-col justify-between h-full">
-           <div class="flex items-center justify-center gap-2 h-full">
-               <!-- <div class="text-lg font-bold">Total Events</div> -->
-               <div class="text-lg text-blue-500 font-bold">{formatTotal ? formatTotal(totalCount) : totalCount.toLocaleString()}</div>
-               <HelpTooltip helpText="Total for the query window shown (start–end). The red “now” line only appears while stats are fresh; the dashboard refetches periodically so the window stays current." help={true}/>
-           </div>
-           <div class="flex items-center justify-center">
-              <div class="text-[10px] text-muted-foreground font-medium">{humanRangeStart}–{humanEnd}</div>
-            </div>
-           <Separator/>
-           <div class="flex items-center justify-center gap-2 h-full">
-             <div class="text-lg text-[#F47D4A] font-bold">{formatTotal ? formatTotal(countInLastBucket) : countInLastBucket.toLocaleString()}</div>
-             <HelpTooltip helpText="The number of events in the last bucket." help={true}/>
-           </div>
-           <div class="flex items-center justify-center">
-                <div class="text-[10px] text-muted-foreground font-medium">{humanLastBucket}-{humanStart}</div>
-           </div>
-           <Separator/>
-           <div class="flex items-center justify-center gap-2 h-full">
-               <!-- <div class="text-lg font-bold">Events In Last Bucket</div> -->
-               <div class="text-lg text-[#88a550] font-bold">{formatTotal ? formatTotal(countInBucket) : countInBucket.toLocaleString()}</div>
-               <HelpTooltip helpText="The number of events in the current bucket." help={true}/>
-           </div>
-           <div class="flex items-center justify-center">
-                <div class="text-[10px] text-muted-foreground font-medium">{humanStart}-{humanEnd}</div>
-            </div>
-       </div>
-   </div>
-   <Separator orientation="vertical" class="h-full"/>
-        <div class="p-2 shadow-sm w-3/4 h-full overflow-hidden">
-          <canvas bind:this={canvas} class="w-full h-full max-w-full max-h-full"></canvas>
+  {/if}
+  <div class="flex flex-row bg-muted/20 rounded-md w-full h-full overflow-hidden">
+    <div class="p-2 shadow-sm w-1/4 h-full overflow-hidden">
+      <div class="flex flex-col justify-between h-full">
+        <div class="flex items-center justify-center gap-2 h-full">
+          <div class="text-lg text-blue-500 font-bold">{formatTotal ? formatTotal(totalCount) : totalCount.toLocaleString()}</div>
+          <HelpTooltip helpText="Total for the query window shown (start–end). The red “now” line only appears while stats are fresh; the dashboard refetches periodically so the window stays current." help={true} />
         </div>
+        <div class="flex items-center justify-center">
+          <div class="text-[10px] text-muted-foreground font-medium">{humanRangeStart}–{humanEnd}</div>
+        </div>
+        <Separator />
+        <div class="flex items-center justify-center gap-2 h-full">
+          <div class="text-lg text-[#F47D4A] font-bold">{formatTotal ? formatTotal(countInLastBucket) : countInLastBucket.toLocaleString()}</div>
+          <HelpTooltip helpText="The number of events in the last bucket." help={true} />
+        </div>
+        <div class="flex items-center justify-center">
+          <div class="text-[10px] text-muted-foreground font-medium">{humanLastBucket}-{humanStart}</div>
+        </div>
+        <Separator />
+        <div class="flex items-center justify-center gap-2 h-full">
+          <div class="text-lg text-[#88a550] font-bold">{formatTotal ? formatTotal(countInBucket) : countInBucket.toLocaleString()}</div>
+          <HelpTooltip helpText="The number of events in the current bucket." help={true} />
+        </div>
+        <div class="flex items-center justify-center">
+          <div class="text-[10px] text-muted-foreground font-medium">{humanStart}-{humanEnd}</div>
+        </div>
+      </div>
     </div>
+    <Separator orientation="vertical" class="h-full" />
+    <div class="p-2 shadow-sm w-3/4 h-full overflow-hidden">
+      {#if GenericBucketLineChartInner && data}
+        <GenericBucketLineChartInner
+          {data}
+          {chartLabel}
+          {start}
+          {end}
+          {lastBucket}
+          rangeStart={effectiveRangeStart}
+          {checkPointValue}
+          {showLogarithmic}
+        />
+      {/if}
+    </div>
+  </div>
 </div>

--- a/webapp/src/lib/client/components/features/charts/generic-line-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/generic-line-chart-inner.svelte
@@ -5,7 +5,7 @@
   import { onMount } from "svelte";
   import { humanize } from "$lib/utils";
   import type { DashboardStatsValue } from "$lib/types";
-  import { chartYBaseline } from "./y-axis";
+  import { chartYBaseline, logSafe } from "./y-axis";
 
   interface Props {
     data: DashboardStatsValue[];
@@ -25,7 +25,7 @@
   });
 
   const chartData = $derived(
-    data.map((d) => ({ time: new Date(d.time), value: d.value || 0 }))
+    data.map((d) => ({ time: new Date(d.time), value: logSafe(d.value || 0, showLogarithmic) }))
   );
 
   // Extend the x domain to include "now" so the now-line is always visible.
@@ -83,7 +83,9 @@
         hideIndicator
       >
         {#snippet formatter({ value })}
-          <span>{tooltipLabel}: {formatValue(value as number)}</span>
+          {#if value != null}
+            <span>{tooltipLabel}: {formatValue(value as number)}</span>
+          {/if}
         {/snippet}
       </Chart.Tooltip>
     {/snippet}

--- a/webapp/src/lib/client/components/features/charts/generic-line-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/generic-line-chart-inner.svelte
@@ -5,6 +5,7 @@
   import { onMount } from "svelte";
   import { humanize } from "$lib/utils";
   import type { DashboardStatsValue } from "$lib/types";
+  import { chartYBaseline } from "./y-axis";
 
   interface Props {
     data: DashboardStatsValue[];
@@ -60,6 +61,7 @@
     y="value"
     yScale={showLogarithmic ? scaleLog() : scaleLinear()}
     yNice
+    yBaseline={chartYBaseline(showLogarithmic)}
     series={[{ key: "value", label: dataSetLabel, color: "#3b82f6" }]}
     props={{
       spline: { class: "stroke-2" },

--- a/webapp/src/lib/client/components/features/charts/generic-line-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/generic-line-chart-inner.svelte
@@ -5,7 +5,7 @@
   import { onMount } from "svelte";
   import { humanize } from "$lib/utils";
   import type { DashboardStatsValue } from "$lib/types";
-  import { chartYBaseline, logSafe } from "./y-axis";
+  import { chartYBaseline, logClamp, logFloor } from "./y-axis";
 
   interface Props {
     data: DashboardStatsValue[];
@@ -24,9 +24,10 @@
     return () => clearInterval(id);
   });
 
-  const chartData = $derived(
-    data.map((d) => ({ time: new Date(d.time), value: logSafe(d.value || 0, showLogarithmic) }))
-  );
+  const chartData = $derived.by(() => {
+    const floor = logFloor(data.map((d) => d.value));
+    return data.map((d) => ({ time: new Date(d.time), value: logClamp(d.value || 0, showLogarithmic, floor) }));
+  });
 
   // Extend the x domain to include "now" so the now-line is always visible.
   const xDomain = $derived.by(() => {

--- a/webapp/src/lib/client/components/features/charts/generic-line-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/generic-line-chart-inner.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import * as Chart from "$lib/client/components/ui/chart/index";
+  import { AnnotationLine, LineChart } from "layerchart";
+  import { scaleTime, scaleLinear, scaleLog } from "d3-scale";
+  import { onMount } from "svelte";
+  import { humanize } from "$lib/utils";
+  import type { DashboardStatsValue } from "$lib/types";
+
+  interface Props {
+    data: DashboardStatsValue[];
+    dataSetLabel: string;
+    tooltipLabel: string;
+    dataIsTimeBased?: boolean;
+    showLogarithmic?: boolean;
+  }
+
+  let { data, dataSetLabel, tooltipLabel, dataIsTimeBased = false, showLogarithmic = false }: Props = $props();
+
+  // Auto-refresh the "now" line every 30s, matching the previous Chart.js behavior.
+  let now = $state(new Date());
+  onMount(() => {
+    const id = setInterval(() => (now = new Date()), 30_000);
+    return () => clearInterval(id);
+  });
+
+  const chartData = $derived(
+    data.map((d) => ({ time: new Date(d.time), value: d.value || 0 }))
+  );
+
+  // Extend the x domain to include "now" so the now-line is always visible.
+  const xDomain = $derived.by(() => {
+    if (!chartData.length) return undefined;
+    let minMs = Infinity;
+    let maxMs = -Infinity;
+    for (const d of chartData) {
+      const t = d.time.getTime();
+      if (t < minMs) minMs = t;
+      if (t > maxMs) maxMs = t;
+    }
+    maxMs = Math.max(maxMs, now.getTime());
+    return [new Date(minMs), new Date(maxMs)] as [Date, Date];
+  });
+
+  const config = $derived({
+    value: { label: dataSetLabel, color: "#3b82f6" },
+  } satisfies Chart.ChartConfig);
+
+  const formatTime = (value: Date | number) =>
+    new Date(value).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+  const formatValue = (value: number) =>
+    dataIsTimeBased ? humanize(value) : value.toLocaleString();
+</script>
+
+<Chart.Container {config} class="h-full w-full">
+  <LineChart
+    data={chartData}
+    x="time"
+    xScale={scaleTime()}
+    {xDomain}
+    y="value"
+    yScale={showLogarithmic ? scaleLog() : scaleLinear()}
+    yNice
+    series={[{ key: "value", label: dataSetLabel, color: "#3b82f6" }]}
+    props={{
+      spline: { class: "stroke-2" },
+      xAxis: { format: (v: Date) => formatTime(v), ticks: 10 },
+      yAxis: { format: (v: number) => formatValue(v) },
+      grid: { class: "stroke-border/40" },
+    }}
+  >
+    {#snippet aboveMarks()}
+      <AnnotationLine
+        x={now}
+        props={{ line: { style: "stroke: #ef4444; stroke-width: 2;" } }}
+      />
+    {/snippet}
+    {#snippet tooltip()}
+      <Chart.Tooltip
+        labelFormatter={(_v, payload) =>
+          formatTime((payload?.[0]?.payload as { time?: Date } | undefined)?.time ?? new Date())}
+        hideIndicator
+      >
+        {#snippet formatter({ value })}
+          <span>{tooltipLabel}: {formatValue(value as number)}</span>
+        {/snippet}
+      </Chart.Tooltip>
+    {/snippet}
+  </LineChart>
+</Chart.Container>

--- a/webapp/src/lib/client/components/features/charts/generic-line-chart.svelte
+++ b/webapp/src/lib/client/components/features/charts/generic-line-chart.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
+  import { browser } from "$app/environment";
+  import type { Component } from "svelte";
   import type { DashboardStatsValue } from "$lib/types";
-  import type { Chart, ChartConfiguration } from "chart.js/auto";
-  import annotationPlugin from "chartjs-plugin-annotation";
-  import { onDestroy, onMount } from "svelte";
   import HelpTooltip from "../../help-tooltip.svelte";
   import { Separator } from "../../ui/separator";
   import { humanize } from "$lib/utils";
@@ -20,228 +19,71 @@
     chartOptions?: ChartOptions;
   }
 
-  let { data, dataSetLabel, tooltipLabel, helpText, dataIsTimeBased = false, includeFullCount = false, includeCurrentValue = false, chartOptions }: Props = $props();
+  let {
+    data,
+    dataSetLabel,
+    tooltipLabel,
+    helpText,
+    dataIsTimeBased = false,
+    includeFullCount = false,
+    includeCurrentValue = false,
+    chartOptions,
+  }: Props = $props();
 
-  let canvas: HTMLCanvasElement | null = $state(null);
-  let chart = $state<Chart | null>(null);
+  let showLogarithmic = $state(false);
 
-    let fullCount: number | undefined = $state(undefined);
-    let currentValue: number | undefined = $state(undefined);
-    let showTrendLine = $state(false);
-    let showLogarithmic = $state(false);
+  const fullCount = $derived(
+    includeFullCount ? data.reduce((acc, d) => acc + (d.value || 0), 0) : undefined
+  );
+  const currentValue = $derived(
+    includeCurrentValue ? data[data.length - 1]?.value : undefined
+  );
 
-  let nowRefreshInterval: ReturnType<typeof setInterval> | null = null;
-
-  function createChartConfig(): ChartConfiguration<"line"> {
-    return {
-      type: "line",
-      data: {
-        labels: [],
-        datasets: [
-          {
-            label: dataSetLabel,
-            data: [],
-            borderColor: "#3b82f6",
-            backgroundColor: "rgba(59, 130, 246, 0.1)",
-            borderWidth: 2,
-            fill: false,
-            tension: 0.1,
-            pointStyle: false,
-          },
-        ],
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        interaction: {
-          intersect: false,
-          mode: "nearest",
-        },
-        plugins: {
-          legend: {
-            display: false,
-          },
-          tooltip: {
-            backgroundColor: "rgba(0, 0, 0, 0.8)",
-            titleColor: "white",
-            bodyColor: "white",
-            borderColor: "#3b82f6",
-            borderWidth: 1,
-            callbacks: {
-              title: function (context) {
-                const timestamp = context[0].parsed.x;
-                return new Date(timestamp).toLocaleTimeString(undefined, {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                });
-              },
-              label: function (context) {
-                return `${tooltipLabel}: ${dataIsTimeBased ? humanize(context.parsed.y) : context.parsed.y.toLocaleString()}`;
-              },
-            },
-          },
-        },
-        scales: {
-          x: {
-            type: "linear",
-            bounds: 'data',
-            grid: {
-              color: "rgba(128, 128, 128, 0.15)",
-            },
-            ticks: {
-              color: "#888888",
-              maxTicksLimit: 10,
-              callback: function (value) {
-                return new Date(value).toLocaleTimeString(undefined, {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                });
-              },
-            },
-          },
-          y: {
-            type: "linear",
-            beginAtZero: true,
-            grid: {
-              color: "rgba(128, 128, 128, 0.15)",
-            },
-            ticks: {
-              color: "#888888",
-              callback: function (value) {
-                return dataIsTimeBased ? humanize(value as number) : value.toLocaleString();
-              },
-            },
-          },
-        },
-      },
-    };
-  }
-
-  async function initChart() {
-    if(!canvas) {
-        return;
-    }
-    try {
-        const { Chart } = await import('chart.js/auto');
-        Chart.register(annotationPlugin);
-        chart = new Chart(canvas, createChartConfig());
-    } catch (error) {
-        console.error('Error initializing chart:', error);
-    }
-  }
-
-  function updateChart() {
-    if (!chart) {
-        return;
-    }
-
-    const xScale = chart.options!.scales!.x as { min?: number; max?: number };
-
-    if (!data?.length) {
-      chart.data.labels = [];
-      chart.data.datasets[0].data = [];
-      delete xScale.min;
-      delete xScale.max;
-      chart.options!.plugins!.annotation = { annotations: {} };
-      chart.options!.scales!.y!.type = showLogarithmic ? "logarithmic" : "linear";
-      chart.update("active");
-      return;
-    }
-
-    const pts = data.map((d: DashboardStatsValue) => ({ x: d.time, y: d.value || 0 }));
-    chart.data.labels = [];
-    chart.data.datasets[0].data = pts as any;
-
-    const nowMs = Date.now();
-    const xs = pts.map((p) => p.x);
-    xScale.min = Math.min(...xs, nowMs);
-    xScale.max = Math.max(...xs, nowMs);
-
-    chart.options!.plugins!.annotation = {
-      annotations: {
-        nowLine: {
-          type: "line",
-          scaleID: "x",
-          value: nowMs,
-          borderColor: "rgba(239, 68, 68, 0.95)",
-          borderWidth: 2,
-        },
-      },
-    };
-
-    chart.options!.scales!.y!.type = showLogarithmic ? "logarithmic" : "linear";
-    chart.update("active");
-
-    if (includeFullCount) {
-        fullCount = data.reduce((acc, d) => acc + (d.value || 0), 0);
-    }
-
-    if (includeCurrentValue) {
-        currentValue = data[data.length - 1]?.value;
-    }
-  }
+  // LayerChart renders client-side only; lazy-load the inner chart behind a browser guard.
+  let GenericLineChartInner: Component<{
+    data: DashboardStatsValue[];
+    dataSetLabel: string;
+    tooltipLabel: string;
+    dataIsTimeBased?: boolean;
+    showLogarithmic?: boolean;
+  }> | null = $state(null);
 
   $effect(() => {
-    if(chart && data) {
-        updateChart();
-    }
-  });
-
-  function refreshNowLine() {
-    if (!chart?.options?.plugins?.annotation) return;
-    const annos = chart.options.plugins.annotation.annotations as Record<string, { value?: number }>;
-    if (!annos?.nowLine) return;
-    const nowMs = Date.now();
-    annos.nowLine.value = nowMs;
-    const xScale = chart.options.scales!.x as { min?: number; max?: number };
-    if (typeof xScale.max === "number" && nowMs > xScale.max) {
-      xScale.max = nowMs;
-    }
-    chart.update("none");
-  }
-
-  onMount(() => {
-    initChart();
-    nowRefreshInterval = setInterval(refreshNowLine, 30_000);
-  });
-
-  onDestroy(() => {
-    if (nowRefreshInterval) {
-      clearInterval(nowRefreshInterval);
-      nowRefreshInterval = null;
-    }
-    if(chart) {
-        chart.destroy();
-        chart = null;
+    if (browser && !GenericLineChartInner) {
+      import("./generic-line-chart-inner.svelte").then((mod) => {
+        GenericLineChartInner = mod.default;
+      });
     }
   });
 </script>
 
 <div class="flex flex-col h-full">
-    <div class="flex flex-row justify-between">
-      <h2 class="text-xl font-semibold text-foreground mb-2">{dataSetLabel}</h2>
-      {#if chartOptions}
-        <ChartOptionsMenu chartOptions={chartOptions} bind:logSwitch={showLogarithmic} />
+  <div class="flex flex-row justify-between">
+    <h2 class="text-xl font-semibold text-foreground mb-2">{dataSetLabel}</h2>
+    {#if chartOptions}
+      <ChartOptionsMenu chartOptions={chartOptions} bind:logSwitch={showLogarithmic} />
+    {/if}
+  </div>
+  <div class="flex flex-row bg-muted/20 rounded-md w-full h-full overflow-hidden">
+    {#if includeFullCount || includeCurrentValue}
+      <div class="p-2 shadow-sm w-1/4 h-full overflow-hidden">
+        <div class="flex flex-col gap-2 justify-between h-full">
+          <div class="flex items-center justify-center gap-2 h-full">
+            {#if dataIsTimeBased}
+              <div class="text-lg text-blue-500 font-bold">{humanize(includeFullCount ? fullCount || 0 : currentValue || 0)}</div>
+            {:else}
+              <div class="text-lg font-bold">{includeFullCount ? fullCount : currentValue}</div>
+            {/if}
+            <HelpTooltip helpText={helpText} info={true} />
+          </div>
+        </div>
+      </div>
+      <Separator orientation="vertical" class="h-full" />
+    {/if}
+    <div class="p-2 shadow-sm w-{includeFullCount || includeCurrentValue ? '3/4' : 'full'} h-full overflow-hidden">
+      {#if GenericLineChartInner}
+        <GenericLineChartInner {data} {dataSetLabel} {tooltipLabel} {dataIsTimeBased} {showLogarithmic} />
       {/if}
     </div>
-    <div class="flex flex-row bg-muted/20 rounded-md w-full h-full overflow-hidden">
-        {#if includeFullCount || includeCurrentValue}
-            <div class="p-2 shadow-sm w-1/4 h-full overflow-hidden">
-                <div class="flex flex-col gap-2 justify-between h-full">
-                    <div class="flex items-center justify-center gap-2 h-full">
-                        {#if dataIsTimeBased}
-                            <div class="text-lg text-blue-500 font-bold">{humanize(includeFullCount ? fullCount || 0 : currentValue || 0)}</div>
-                        {:else}
-                            <div class="text-lg font-bold">{includeFullCount ? fullCount : currentValue}</div>
-                        {/if}
-                        <HelpTooltip helpText={helpText} info={true}/>
-                    </div>
-                </div>
-            </div>
-            <Separator orientation="vertical" class="h-full"/>
-        {/if}
-        <div class="p-2 shadow-sm w-{includeFullCount || includeCurrentValue ? '3/4' : 'full'} h-full overflow-hidden">
-          <canvas bind:this={canvas} class="w-full h-full max-w-full max-h-full"></canvas>
-        </div>
-    </div>
+  </div>
 </div>

--- a/webapp/src/lib/client/components/features/charts/queue-lag-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/queue-lag-chart-inner.svelte
@@ -5,7 +5,7 @@
   import { humanize } from "$lib/utils";
   import type { DashboardStatsValue } from "$lib/types";
   import { createRegressionSeries, type RegressionType } from "./regression";
-  import { chartYBaseline, logClamp, logFloor } from "./y-axis";
+  import { logClamp, logFloor } from "./y-axis";
 
   interface Props {
     sourceLagData: DashboardStatsValue[];
@@ -92,6 +92,13 @@
 </script>
 
 <Chart.Container {config} class="h-full w-full">
+  <!--
+    yBaseline={null}: fit the y-axis to the data range, never to 0. The prior
+    Chart.js queue-lag chart had `beginAtZero` commented out; lag values sit far
+    above zero, so pinning the baseline at 0 flattens the variation. (Unlike
+    generic-line, which used beginAtZero:true, and the bucket area charts, which
+    fill to origin — those keep the 0 baseline via chartYBaseline.)
+  -->
   <LineChart
     data={rows}
     x="time"
@@ -99,7 +106,7 @@
     y="source"
     yScale={showLogarithmic ? scaleLog() : scaleLinear()}
     yNice
-    yBaseline={chartYBaseline(showLogarithmic)}
+    yBaseline={null}
     {series}
     legend
     props={{

--- a/webapp/src/lib/client/components/features/charts/queue-lag-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/queue-lag-chart-inner.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import * as Chart from "$lib/client/components/ui/chart/index";
+  import { LineChart } from "layerchart";
+  import { scaleTime, scaleLinear, scaleLog } from "d3-scale";
+  import { humanize } from "$lib/utils";
+  import type { DashboardStatsValue } from "$lib/types";
+  import { createRegressionSeries, type RegressionType } from "./regression";
+
+  interface Props {
+    sourceLagData: DashboardStatsValue[];
+    queueLagData: DashboardStatsValue[];
+    showLogarithmic?: boolean;
+    trendLineType?: RegressionType;
+    bestFit?: boolean;
+    trendLineLabel?: string;
+  }
+
+  let { sourceLagData, queueLagData, showLogarithmic = false, trendLineType, bestFit = false, trendLineLabel }: Props = $props();
+
+  const showTrend = $derived(Boolean(trendLineType) || bestFit);
+
+  type Row = { time: Date; source: number | null; queue: number | null; trend: number | null };
+
+  const rows = $derived.by<Row[]>(() => {
+    const map = new Map<number, { source: number | null; queue: number | null }>();
+    for (const d of sourceLagData) {
+      const e = map.get(d.time) ?? { source: null, queue: null };
+      e.source = d.value || 0;
+      map.set(d.time, e);
+    }
+    for (const d of queueLagData) {
+      const e = map.get(d.time) ?? { source: null, queue: null };
+      e.queue = d.value || 0;
+      map.set(d.time, e);
+    }
+
+    let predict: ((x: number) => number) | null = null;
+    if (showTrend && sourceLagData.length > 1) {
+      try {
+        // bestFit and an explicit type are mutually exclusive; prefer bestFit when set.
+        const series = createRegressionSeries({
+          data: sourceLagData,
+          offset: -10,
+          type: bestFit ? undefined : trendLineType,
+          bestFit: bestFit || undefined,
+          label: trendLineLabel,
+        });
+        predict = series.predict;
+      } catch (error) {
+        console.warn("queue-lag trend line failed:", error);
+      }
+    }
+
+    return [...map.keys()]
+      .sort((a, b) => a - b)
+      .map((t) => ({
+        time: new Date(t),
+        source: map.get(t)!.source,
+        queue: map.get(t)!.queue,
+        trend: predict ? predict(t) : null,
+      }));
+  });
+
+  const series = $derived([
+    { key: "source", label: "Source Lag", color: "#3b82f6" },
+    { key: "queue", label: "Queue Lag", color: "#ef4444" },
+    ...(showTrend ? [{ key: "trend", label: trendLineLabel ?? "Trend", color: "#16a34a" }] : []),
+  ]);
+
+  const config = $derived({
+    source: { label: "Source Lag", color: "#3b82f6" },
+    queue: { label: "Queue Lag", color: "#ef4444" },
+    trend: { label: trendLineLabel ?? "Trend", color: "#16a34a" },
+  } satisfies Chart.ChartConfig);
+
+  const formatTime = (value: Date | number) =>
+    new Date(value).toLocaleTimeString(undefined, { hourCycle: "h23", hour: "2-digit", minute: "2-digit" });
+</script>
+
+<Chart.Container {config} class="h-full w-full">
+  <LineChart
+    data={rows}
+    x="time"
+    xScale={scaleTime()}
+    y="source"
+    yScale={showLogarithmic ? scaleLog() : scaleLinear()}
+    yNice
+    {series}
+    legend
+    props={{
+      spline: { class: "stroke-2" },
+      xAxis: { format: (v: Date) => formatTime(v), ticks: 10 },
+      yAxis: { format: (v: number) => humanize(v) },
+      grid: { class: "stroke-border/40" },
+    }}
+  >
+    {#snippet tooltip()}
+      <Chart.Tooltip
+        labelFormatter={(_v, payload) =>
+          formatTime((payload?.[0]?.payload as { time?: Date } | undefined)?.time ?? new Date())}
+      >
+        {#snippet formatter({ value, name })}
+          <span>{name}: {humanize(value as number)}</span>
+        {/snippet}
+      </Chart.Tooltip>
+    {/snippet}
+  </LineChart>
+</Chart.Container>

--- a/webapp/src/lib/client/components/features/charts/queue-lag-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/queue-lag-chart-inner.svelte
@@ -5,6 +5,7 @@
   import { humanize } from "$lib/utils";
   import type { DashboardStatsValue } from "$lib/types";
   import { createRegressionSeries, type RegressionType } from "./regression";
+  import { chartYBaseline } from "./y-axis";
 
   interface Props {
     sourceLagData: DashboardStatsValue[];
@@ -64,7 +65,17 @@
   const series = $derived([
     { key: "source", label: "Source Lag", color: "#3b82f6" },
     { key: "queue", label: "Queue Lag", color: "#ef4444" },
-    ...(showTrend ? [{ key: "trend", label: trendLineLabel ?? "Trend", color: "#16a34a" }] : []),
+    ...(showTrend
+      ? [
+          {
+            key: "trend",
+            label: trendLineLabel ?? "Trend",
+            color: "#16a34a",
+            // Dashed to match the prior Chart.js trend line (borderDash).
+            props: { style: "stroke-dasharray: 6 4;" },
+          },
+        ]
+      : []),
   ]);
 
   const config = $derived({
@@ -85,6 +96,7 @@
     y="source"
     yScale={showLogarithmic ? scaleLog() : scaleLinear()}
     yNice
+    yBaseline={chartYBaseline(showLogarithmic)}
     {series}
     legend
     props={{

--- a/webapp/src/lib/client/components/features/charts/queue-lag-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/queue-lag-chart-inner.svelte
@@ -35,7 +35,11 @@
       map.set(d.time, e);
     }
 
-    let predict: ((x: number) => number) | null = null;
+    // Trend keyed by timestamp. Use the fitted regression `points` (windowed to
+    // the last 10 samples via offset: -10), NOT predict() across the whole axis —
+    // the prior Chart.js chart plotted only those windowed points, so the trend
+    // should cover the same recent segment, not extrapolate over the full range.
+    let trendByTime: Map<number, number> | null = null;
     if (showTrend && sourceLagData.length > 1) {
       try {
         // bestFit and an explicit type are mutually exclusive; prefer bestFit when set.
@@ -46,7 +50,7 @@
           bestFit: bestFit || undefined,
           label: trendLineLabel,
         });
-        predict = series.predict;
+        trendByTime = new Map(series.points.map((p) => [p.x, p.y]));
       } catch (error) {
         console.warn("queue-lag trend line failed:", error);
       }
@@ -61,7 +65,7 @@
         time: new Date(t),
         source: logClamp(map.get(t)!.source, showLogarithmic, floor),
         queue: logClamp(map.get(t)!.queue, showLogarithmic, floor),
-        trend: logClamp(predict ? predict(t) : null, showLogarithmic, floor),
+        trend: logClamp(trendByTime?.get(t) ?? null, showLogarithmic, floor),
       }));
   });
 

--- a/webapp/src/lib/client/components/features/charts/queue-lag-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/queue-lag-chart-inner.svelte
@@ -5,7 +5,7 @@
   import { humanize } from "$lib/utils";
   import type { DashboardStatsValue } from "$lib/types";
   import { createRegressionSeries, type RegressionType } from "./regression";
-  import { chartYBaseline } from "./y-axis";
+  import { chartYBaseline, logSafe } from "./y-axis";
 
   interface Props {
     sourceLagData: DashboardStatsValue[];
@@ -56,9 +56,9 @@
       .sort((a, b) => a - b)
       .map((t) => ({
         time: new Date(t),
-        source: map.get(t)!.source,
-        queue: map.get(t)!.queue,
-        trend: predict ? predict(t) : null,
+        source: logSafe(map.get(t)!.source, showLogarithmic),
+        queue: logSafe(map.get(t)!.queue, showLogarithmic),
+        trend: logSafe(predict ? predict(t) : null, showLogarithmic),
       }));
   });
 
@@ -112,7 +112,9 @@
           formatTime((payload?.[0]?.payload as { time?: Date } | undefined)?.time ?? new Date())}
       >
         {#snippet formatter({ value, name })}
-          <span>{name}: {humanize(value as number)}</span>
+          {#if value != null}
+            <span>{name}: {humanize(value as number)}</span>
+          {/if}
         {/snippet}
       </Chart.Tooltip>
     {/snippet}

--- a/webapp/src/lib/client/components/features/charts/queue-lag-chart-inner.svelte
+++ b/webapp/src/lib/client/components/features/charts/queue-lag-chart-inner.svelte
@@ -5,7 +5,7 @@
   import { humanize } from "$lib/utils";
   import type { DashboardStatsValue } from "$lib/types";
   import { createRegressionSeries, type RegressionType } from "./regression";
-  import { chartYBaseline, logSafe } from "./y-axis";
+  import { chartYBaseline, logClamp, logFloor } from "./y-axis";
 
   interface Props {
     sourceLagData: DashboardStatsValue[];
@@ -52,13 +52,16 @@
       }
     }
 
+    // Shared floor across both series (one y-axis) for clamping 0s on a log scale.
+    const floor = logFloor([...sourceLagData.map((d) => d.value), ...queueLagData.map((d) => d.value)]);
+
     return [...map.keys()]
       .sort((a, b) => a - b)
       .map((t) => ({
         time: new Date(t),
-        source: logSafe(map.get(t)!.source, showLogarithmic),
-        queue: logSafe(map.get(t)!.queue, showLogarithmic),
-        trend: logSafe(predict ? predict(t) : null, showLogarithmic),
+        source: logClamp(map.get(t)!.source, showLogarithmic, floor),
+        queue: logClamp(map.get(t)!.queue, showLogarithmic, floor),
+        trend: logClamp(predict ? predict(t) : null, showLogarithmic, floor),
       }));
   });
 

--- a/webapp/src/lib/client/components/features/charts/queue-lag-chart.svelte
+++ b/webapp/src/lib/client/components/features/charts/queue-lag-chart.svelte
@@ -1,239 +1,98 @@
 <script lang="ts">
-  import type { DashboardStats, DashboardStatsValue, StatsRange } from "$lib/types";
+  import { browser } from "$app/environment";
+  import type { Component } from "svelte";
+  import type { DashboardStats, DashboardStatsValue } from "$lib/types";
   import { humanize } from "$lib/utils";
-  import type { ChartConfiguration } from "chart.js/auto";
-  import Chart from "chart.js/auto";
-  import { onDestroy, onMount } from "svelte";
   import { Separator } from "../../ui/separator";
   import HelpTooltip from "../../help-tooltip.svelte";
   import type { ChartOptions } from "../chart-details-pane/types";
   import ChartOptionsMenu from "./chart-options.svelte";
-  import { createDataSet, type RegressionType } from "./regression";
+  import type { RegressionType } from "./regression";
 
+  interface Props {
+    data: DashboardStats | null;
+    queueId: string;
+    chartOptions?: ChartOptions;
+  }
 
-    interface Props {
-        data: DashboardStats | null;
-        queueId: string;
-        chartOptions?: ChartOptions;
+  let { data, queueId, chartOptions }: Props = $props();
+
+  let showLogarithmic = $state<boolean>(false);
+  let trendLineType = $state<RegressionType | undefined>("linear");
+  let bestFit = $state<boolean>(false);
+
+  const lagData = $derived.by(() => {
+    const read = data?.queues?.read?.[queueId];
+    if (!read || (!read.source_lags && !read.queue_lags)) {
+      return { sourceLagData: [] as DashboardStatsValue[], queueLagData: [] as DashboardStatsValue[] };
     }
+    return {
+      sourceLagData: [...read.source_lags].sort((a, b) => a.time - b.time),
+      queueLagData: [...read.queue_lags].sort((a, b) => a.time - b.time),
+    };
+  });
 
-    let { data, queueId, chartOptions }: Props = $props();
+  const currentSourceLag = $derived(
+    [...lagData.sourceLagData].reverse().find((d) => d.value !== 0)?.value ?? 0
+  );
+  const currentQueueLag = $derived(
+    [...lagData.queueLagData].reverse().find((d) => d.value !== 0)?.value ?? 0
+  );
 
-    let canvas: HTMLCanvasElement;
-    let chart = $state<Chart | null>(null);
-    let currentSourceLag = $state<number>(0);
-    let currentQueueLag = $state<number>(0);    
-    let showLogarithmic = $state<boolean>(false);
-    let trendLineType = $state<RegressionType | undefined>('linear');
-    let bestFit = $state<boolean>(false);
-    
+  // LayerChart renders client-side only; lazy-load the inner chart behind a browser guard.
+  let QueueLagChartInner: Component<{
+    sourceLagData: DashboardStatsValue[];
+    queueLagData: DashboardStatsValue[];
+    showLogarithmic?: boolean;
+    trendLineType?: RegressionType;
+    bestFit?: boolean;
+    trendLineLabel?: string;
+  }> | null = $state(null);
 
-
-    function createChartConfig(): ChartConfiguration<'line'> {
-        return {
-            type: 'line',
-            data: {
-                labels: [],
-                datasets: [
-                    {
-                        label: 'Source Lag',
-                        data: [],
-                        fill: false,
-                        borderColor: '#3b82f6',
-                        borderWidth: 2,
-                        tension: 0.3,
-                        pointStyle: false,
-                        xAxisID: 'x',
-                    },
-                    {
-                        label: 'Queue Lag',
-                        data: [],
-                        fill: false,
-                        borderColor: '#ef4444',
-                        borderWidth: 2,
-                        tension: 0.3,
-                        pointStyle: false,
-                        xAxisID: 'x',
-                    }
-                ]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                interaction: {
-                    intersect: false,
-                    mode: 'nearest'
-                },
-                plugins: {
-                    legend: {
-                        display: true
-                    },
-                    tooltip: {
-                        backgroundColor: 'rgba(0, 0, 0, 0.8)',
-                        titleColor: 'white',
-                        bodyColor: 'white',
-                        borderColor: '#3b82f6',
-                        borderWidth: 1,
-                        callbacks: {
-                            title: function(context) {
-                                const timestamp = context[0].parsed.x;
-                                return new Date(timestamp).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-                            },
-                            label: function(context) {
-                                return `${humanize(context.parsed.y)}`;
-                            }
-                        }
-                    }
-                },
-                scales: {
-                    x: {
-                        bounds: 'data',
-                        type: 'linear',
-                        grid: {
-                            color: 'rgba(128, 128, 128, 0.15)'
-                        },
-                        ticks: {
-                            color: '#888888',
-                            maxTicksLimit: 10,
-                            callback: function(value) {
-                                return new Date(value).toLocaleTimeString(undefined, { hourCycle: 'h23', hour: '2-digit', minute: '2-digit' });
-                            },
-                            minRotation: 50,
-                            maxRotation: 60,
-                        }
-                    },
-                    y: {
-                        type: 'linear',
-                        // beginAtZero: true,
-                        grid: {
-                            color: 'rgba(128, 128, 128, 0.15)'
-                        },
-                        ticks: {
-                            color: '#888888',
-                            callback: function(value) {
-                                return humanize(value as number);
-                            }
-                        }
-                    }
-                }
-            }
-        }
+  $effect(() => {
+    if (browser && !QueueLagChartInner) {
+      import("./queue-lag-chart-inner.svelte").then((mod) => {
+        QueueLagChartInner = mod.default;
+      });
     }
-
-    function processChartData(dashboardStats: DashboardStats | null): { sourceLagData: DashboardStatsValue[], queueLagData: DashboardStatsValue[] } {
-        if(!dashboardStats || !dashboardStats.queues.read || !dashboardStats.queues.read?.[queueId] || (!dashboardStats.queues.read?.[queueId]?.source_lags && !dashboardStats.queues.read?.[queueId]?.queue_lags)) {
-            return { sourceLagData: [], queueLagData: [] };
-        }
-
-        // const queueLagData = dashboardStats.queues.read[queueId].lags;
-        const sourceLagData = dashboardStats.queues.read[queueId].source_lags.sort((a, b) => a.time - b.time);
-        const queueLagData = dashboardStats.queues.read[queueId].queue_lags.sort((a, b) => a.time - b.time);
-
-        currentSourceLag = [...sourceLagData].reverse().find(d => d.value !== 0)?.value ?? 0;
-        currentQueueLag = [...queueLagData].reverse().find(d => d.value !== 0)?.value ?? 0;
-        
-        return { sourceLagData, queueLagData };
-    }
-
-    async function initChart() {
-        try {
-            const { Chart } = await import('chart.js/auto');
-            if(!canvas) {
-                return;
-            }
-
-            chart = new Chart(canvas, createChartConfig());
-        } catch (error) {
-            console.error('Error initializing chart:', error);
-        }
-    }
-
-    function updateChart() {
-        if(!chart) {
-            return
-        }
-
-        const chartData = processChartData(data);
-        chart.data.labels = chartData.sourceLagData.map((d: DashboardStatsValue) => d.time);
-        chart.data.datasets[0].data = chartData.sourceLagData.map((d: DashboardStatsValue) => d.value || 0);
-        chart.data.datasets[1].data = chartData.queueLagData.map((d: DashboardStatsValue) => d.value || 0);
-        chart.options!.scales!.y!.type = showLogarithmic ? 'logarithmic' : 'linear';
-
-        // Only create trend line if either trendLineType or bestFit is selected
-        if (trendLineType || bestFit) {
-            const datasetOptions: any = {
-                data: chartData.sourceLagData,
-                offset: -10,
-                label: chartOptions?.trendLineLabel,
-            };
-            
-            if (trendLineType) {
-                datasetOptions.type = trendLineType;
-            }
-            
-            if (bestFit === true) {
-                datasetOptions.bestFit = true;
-            }
-            
-
-            chart.data.datasets[2] = createDataSet(datasetOptions);
-        } else {
-            // Remove trend line dataset if neither is selected
-            if (chart.data.datasets.length > 2) {
-                chart.data.datasets = chart.data.datasets.slice(0, 2);
-            }
-        }
-        chart.update('active');
-    }
-
-    $effect(() => {
-        if(chart && data) {
-            updateChart();
-        }
-    });
-
-    onMount(() => {
-        initChart();
-    });
-
-    onDestroy(() => {
-        if(chart) {
-            chart.destroy();
-            chart = null;
-        }
-    });
+  });
 </script>
 
 <div class="flex flex-col h-full">
-    <div class="flex flex-row justify-between">
-        <h2 class="text-xl font-semibold text-foreground mb-2">Queue and Source Lag</h2>
-        <!-- <div class="flex flex-row items-center gap-2">
-            <Label for="logarithmic-switch">Log Scaling</Label>
-            <Switch id="logarithmic-switch" bind:checked={showLogarithmic} on:change={updateChart} />
-        </div> -->
-        {#if chartOptions}
-            <ChartOptionsMenu chartOptions={chartOptions} bind:logSwitch={showLogarithmic} bind:regressionType={trendLineType} bind:bestFit={bestFit}/>
-        {/if}
-    </div>
-    <div class="flex flex-row bg-muted/20 rounded-md w-full h-full overflow-hidden">
-        <div class="p-2 shadow-sm w-1/4 h-full overflow-hidden">
-            <div class="flex flex-col gap-2 justify-between h-full">
-                <div class="flex items-center justify-center gap-2 h-full">
-                    <div class="text-md font-bold">Source Lag</div>
-                    <div class="text-md text-blue-500 font-bold">{humanize(currentSourceLag)}</div>
-                    <HelpTooltip helpText="The lag between the source and the queue." help={true}/>
-                </div>
-                <Separator/>
-                <div class="flex items-center justify-center gap-2 h-full">
-                    <div class="text-md font-bold">Queue Lag</div>
-                    <div class="text-md text-red-500 font-bold">{humanize(currentQueueLag)}</div>
-                    <HelpTooltip helpText="The lag within the queue processing." help={true}/>
-                </div>
-            </div>
+  <div class="flex flex-row justify-between">
+    <h2 class="text-xl font-semibold text-foreground mb-2">Queue and Source Lag</h2>
+    {#if chartOptions}
+      <ChartOptionsMenu chartOptions={chartOptions} bind:logSwitch={showLogarithmic} bind:regressionType={trendLineType} bind:bestFit={bestFit} />
+    {/if}
+  </div>
+  <div class="flex flex-row bg-muted/20 rounded-md w-full h-full overflow-hidden">
+    <div class="p-2 shadow-sm w-1/4 h-full overflow-hidden">
+      <div class="flex flex-col gap-2 justify-between h-full">
+        <div class="flex items-center justify-center gap-2 h-full">
+          <div class="text-md font-bold">Source Lag</div>
+          <div class="text-md text-blue-500 font-bold">{humanize(currentSourceLag)}</div>
+          <HelpTooltip helpText="The lag between the source and the queue." help={true} />
         </div>
-        <Separator orientation="vertical" class="h-full"/>
-        <div class="p-2 shadow-sm w-3/4 h-full overflow-hidden">
-          <canvas bind:this={canvas} class="w-full h-full max-w-full max-h-full"></canvas>
+        <Separator />
+        <div class="flex items-center justify-center gap-2 h-full">
+          <div class="text-md font-bold">Queue Lag</div>
+          <div class="text-md text-red-500 font-bold">{humanize(currentQueueLag)}</div>
+          <HelpTooltip helpText="The lag within the queue processing." help={true} />
         </div>
+      </div>
     </div>
+    <Separator orientation="vertical" class="h-full" />
+    <div class="p-2 shadow-sm w-3/4 h-full overflow-hidden">
+      {#if QueueLagChartInner}
+        <QueueLagChartInner
+          sourceLagData={lagData.sourceLagData}
+          queueLagData={lagData.queueLagData}
+          {showLogarithmic}
+          {trendLineType}
+          {bestFit}
+          trendLineLabel={chartOptions?.trendLineLabel}
+        />
+      {/if}
+    </div>
+  </div>
 </div>

--- a/webapp/src/lib/client/components/features/charts/regression.ts
+++ b/webapp/src/lib/client/components/features/charts/regression.ts
@@ -1,6 +1,14 @@
 import type { DashboardStatsValue } from "$lib/types";
-import type { ChartDataset } from "chart.js/auto";
-import regression, { type DataPoint } from "regression";
+import regression from "regression";
+
+/** Library-agnostic trend-line series: fitted points plus a predictor for arbitrary x. */
+export interface RegressionSeries {
+    /** Fitted regression points, sorted by x (time). */
+    points: { x: number; y: number }[];
+    /** Predicts the regression y value at an arbitrary x (time). */
+    predict: (x: number) => number;
+    label?: string;
+}
 
 export type RegressionType = 'linear' | 'exponential' | 'polynomial' | 'power' | 'logarithmic';
 export const regressionTypes: RegressionType[] = ['linear', 'exponential', 'polynomial', 'power', 'logarithmic']
@@ -24,7 +32,7 @@ function convertToRegressionValidData(data: DashboardStatsValue[]): {data: [numb
     return {data: data.map((item) => [item.time, item.value]), xVals: data.filter((item) => item.value == 0).map((item) => [item.time, item.value])};
 }
 
-export function createDataSet(opts: RegressionOptions): ChartDataset<"line"> {
+export function createRegressionSeries(opts: RegressionOptions): RegressionSeries {
     if(!opts.type && !opts.bestFit) {
         throw new Error('Either type or bestFit must be provided');
     }
@@ -77,14 +85,9 @@ export function createDataSet(opts: RegressionOptions): ChartDataset<"line"> {
         y: item[1],
     })).concat(extendedData).sort((a, b) => a.x - b.x);
     return {
-        // labels: regressionLine.map((item) => item.x),
-        data: regressionLine,
-        borderColor: 'green',
-        borderWidth: 2,
-        borderDash: [5, 5],
-        pointStyle: false,
+        points: regressionLine,
+        predict: (x: number) => reg!.predict(x)[1],
         label: opts.label,
-        xAxisID: 'x',
     };
 }
 

--- a/webapp/src/lib/client/components/features/charts/y-axis.ts
+++ b/webapp/src/lib/client/components/features/charts/y-axis.ts
@@ -16,18 +16,40 @@ export function chartYBaseline(showLogarithmic: boolean): number | null {
 }
 
 /**
- * Sanitize a y-value for the active scale.
+ * Smallest positive value across a series — the floor used to clamp non-positive
+ * values on a log axis (see {@link logClamp}). Falls back to 1 when the series has
+ * no positive values (nothing meaningful to plot on a log scale).
+ */
+export function logFloor(values: Array<number | null | undefined>): number {
+  let min = Infinity;
+  for (const v of values) {
+    if (v != null && v > 0 && v < min) min = v;
+  }
+  return Number.isFinite(min) ? min : 1;
+}
+
+/**
+ * Clamp a y-value for the active scale.
  *
  * Real Bus data contains 0s (e.g. buckets with no events/errors). A `scaleLog`
  * cannot place a non-positive value — `log(0) = -Infinity`, `log(-n) = NaN` —
  * so a single 0 in the series turns the whole path into `M0,NaN…` and the chart
  * renders blank. `yBaseline` alone does NOT fix this: it controls the domain, not
- * the per-point values. On a log axis we therefore map non-positive values to
- * `null` (a gap: the point has no logarithmic position) instead of feeding NaN to
- * the path. On a linear axis the value passes through unchanged.
+ * the per-point values.
+ *
+ * On a log axis we raise non-positive values to `floor` (the smallest positive
+ * value in the series) so the line stays **continuous** and 0s render at the
+ * bottom of the axis — matching the prior Chart.js logarithmic behavior — rather
+ * than punching gaps into the series. On a linear axis the value passes through
+ * unchanged. Structural `null`s (deliberate gaps, e.g. a bucket series outside its
+ * window) are preserved as `null`, not floored.
  */
-export function logSafe(value: number | null | undefined, showLogarithmic: boolean): number | null {
+export function logClamp(
+  value: number | null | undefined,
+  showLogarithmic: boolean,
+  floor: number,
+): number | null {
   if (value == null) return null;
-  if (showLogarithmic && value <= 0) return null;
+  if (showLogarithmic && value <= 0) return floor;
   return value;
 }

--- a/webapp/src/lib/client/components/features/charts/y-axis.ts
+++ b/webapp/src/lib/client/components/features/charts/y-axis.ts
@@ -1,0 +1,16 @@
+/**
+ * Y-axis baseline helper for the LayerChart line/area charts (ES-3031).
+ *
+ * LayerChart's LineChart/AreaChart anchor the y-domain at 0 by default
+ * (`yBaseline={0}`), so the domain becomes `[min(0, ...values), max(...)]`.
+ * That is correct for a linear scale (fills/lines reference zero), but a
+ * logarithmic scale cannot contain 0: `log(0) = -Infinity`, which makes every
+ * point map to `NaN` and the chart renders an empty `M0,NaN…` path.
+ *
+ * For the logarithmic case we therefore drop the baseline (`null`) so the domain
+ * is derived purely from the data extents (all positive); for the linear case we
+ * keep the zero baseline to preserve the prior Chart.js fill-to-zero behavior.
+ */
+export function chartYBaseline(showLogarithmic: boolean): number | null {
+  return showLogarithmic ? null : 0;
+}

--- a/webapp/src/lib/client/components/features/charts/y-axis.ts
+++ b/webapp/src/lib/client/components/features/charts/y-axis.ts
@@ -14,3 +14,20 @@
 export function chartYBaseline(showLogarithmic: boolean): number | null {
   return showLogarithmic ? null : 0;
 }
+
+/**
+ * Sanitize a y-value for the active scale.
+ *
+ * Real Bus data contains 0s (e.g. buckets with no events/errors). A `scaleLog`
+ * cannot place a non-positive value — `log(0) = -Infinity`, `log(-n) = NaN` —
+ * so a single 0 in the series turns the whole path into `M0,NaN…` and the chart
+ * renders blank. `yBaseline` alone does NOT fix this: it controls the domain, not
+ * the per-point values. On a log axis we therefore map non-positive values to
+ * `null` (a gap: the point has no logarithmic position) instead of feeding NaN to
+ * the path. On a linear axis the value passes through unchanged.
+ */
+export function logSafe(value: number | null | undefined, showLogarithmic: boolean): number | null {
+  if (value == null) return null;
+  if (showLogarithmic && value <= 0) return null;
+  return value;
+}

--- a/webapp/tests/lib/client/components/features/charts/bucket-totals.test.ts
+++ b/webapp/tests/lib/client/components/features/charts/bucket-totals.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { computeBucketTotals } from '$comps/features/charts/bucket-totals';
+import type { DashboardStatsValue } from '$lib/types';
+
+/**
+ * Regression coverage for the bucket line chart's "total" rows (ES-3031).
+ * The Chart.js -> LayerChart migration must not change the numbers shown to users,
+ * so these tests pin the aggregation windows and override precedence that used to be
+ * inline in generic-bucket-line-chart.svelte.
+ *
+ * Windows (from the original component):
+ *   countInBucket     = sum over time in [start, end]              (inclusive)
+ *   totalCount        = sum over time in [effectiveRangeStart, end](inclusive)
+ *   countInLastBucket = sum over time in [lastBucket, start)       (half-open)
+ */
+
+// times: 0..40; value === time so sums are easy to reason about.
+const data: DashboardStatsValue[] = Array.from({ length: 5 }, (_, i) => ({
+  time: i * 10, // 0, 10, 20, 30, 40
+  value: i * 10,
+}));
+
+const base = {
+  data,
+  lastBucket: 10, // "last" bucket window is [10, 20)
+  start: 20, // current bucket starts at 20
+  end: 40,
+  effectiveRangeStart: 0,
+};
+
+describe('computeBucketTotals', () => {
+  it('sums the current-bucket window [start, end] inclusive of both ends', () => {
+    // times 20,30,40 -> 20+30+40
+    expect(computeBucketTotals(base).countInBucket).toBe(90);
+  });
+
+  it('sums the full window [effectiveRangeStart, end] inclusive', () => {
+    // times 0,10,20,30,40 -> 100
+    expect(computeBucketTotals(base).totalCount).toBe(100);
+  });
+
+  it('sums the last-bucket window [lastBucket, start) excluding start', () => {
+    // times in [10, 20) -> only time 10 -> 10 (time 20 is excluded)
+    expect(computeBucketTotals(base).countInLastBucket).toBe(10);
+  });
+
+  it('honors effectiveRangeStart for totalCount (window can start after 0)', () => {
+    // [20, 40] -> 20+30+40 = 90
+    expect(computeBucketTotals({ ...base, effectiveRangeStart: 20 }).totalCount).toBe(90);
+  });
+
+  it('treats null data as an empty series (all zero)', () => {
+    expect(computeBucketTotals({ ...base, data: null })).toEqual({
+      countInBucket: 0,
+      totalCount: 0,
+      countInLastBucket: 0,
+    });
+  });
+
+  it('ignores non-numeric values rather than producing NaN', () => {
+    const dirty = [
+      { time: 25, value: Number.NaN },
+      { time: 30, value: 5 },
+    ] as unknown as DashboardStatsValue[];
+    expect(computeBucketTotals({ ...base, data: dirty }).countInBucket).toBe(5);
+  });
+
+  describe('override precedence', () => {
+    it('uses a finite override in place of the computed value', () => {
+      const totals = computeBucketTotals({
+        ...base,
+        overrideTotal: 12345,
+        overrideCountInBucket: 7,
+        overrideCountInLastBucket: 3,
+      });
+      expect(totals.totalCount).toBe(12345);
+      expect(totals.countInBucket).toBe(7);
+      expect(totals.countInLastBucket).toBe(3);
+    });
+
+    it('accepts 0 as a valid override (finite, not falsy-skipped)', () => {
+      expect(computeBucketTotals({ ...base, overrideCountInBucket: 0 }).countInBucket).toBe(0);
+    });
+
+    it('falls back to the computed value when the override is undefined or non-finite', () => {
+      expect(
+        computeBucketTotals({ ...base, overrideCountInBucket: undefined }).countInBucket
+      ).toBe(90);
+      expect(
+        computeBucketTotals({ ...base, overrideTotal: Number.NaN }).totalCount
+      ).toBe(100);
+      expect(
+        computeBucketTotals({ ...base, overrideCountInLastBucket: Infinity }).countInLastBucket
+      ).toBe(10);
+    });
+  });
+});

--- a/webapp/tests/lib/client/components/features/charts/generic-bucket-line-chart.props.test.ts
+++ b/webapp/tests/lib/client/components/features/charts/generic-bucket-line-chart.props.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import type { ComponentProps } from 'svelte';
+import type GenericBucketLineChart from '$comps/features/charts/generic-bucket-line-chart.svelte';
+import type { DashboardStatsValue, StatsRange } from '$lib/types';
+import type { ChartOptions } from '$comps/features/chart-details-pane/types';
+
+/**
+ * Prop-contract guard for GenericBucketLineChart (ES-3031).
+ *
+ * The Chart.js -> LayerChart migration is an internal implementation swap: the wrapper's
+ * public props are the shape its consumers (bot-dashboard-tab, queue-dashboard-tab,
+ * chart-details-pane) depend on, and they must NOT drift. This is a TYPE-LEVEL assertion —
+ * it is enforced by `pnpm check` (svelte-check / tsc), not at vitest runtime. If a prop is
+ * renamed, removed, retyped, or its optionality flips, `Expected` and `Actual` diverge and
+ * the file fails to type-check.
+ *
+ * This is a regression-style guard added after the fact (the change is internal), not an
+ * immutable seam contract test.
+ */
+
+// Exact-equality helper (bidirectional, so added/removed props both fail).
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type Actual = ComponentProps<typeof GenericBucketLineChart>;
+
+type Expected = {
+  data: DashboardStatsValue[] | null;
+  chartLabel: string;
+  range: StatsRange;
+  start: number;
+  end: number;
+  rangeStart?: number;
+  checkPointValue?: number;
+  chartOptions?: ChartOptions;
+  formatTotal?: (value: number) => string;
+  overrideTotal?: number;
+  overrideCountInLastBucket?: number;
+  overrideCountInBucket?: number;
+  showTitle?: boolean;
+};
+
+// Compile-time failure here (caught by `pnpm check`) means the prop contract changed.
+type _PropContract = Expect<Equal<Actual, Expected>>;
+
+describe('GenericBucketLineChart prop contract', () => {
+  it('is enforced at type-check time (see `pnpm check`)', () => {
+    // No runtime behavior to assert — the guard is the `_PropContract` type above.
+    // This keeps the file visible to `vitest run` alongside the type check.
+    expect(true).toBe(true);
+  });
+});

--- a/webapp/tests/lib/client/components/features/charts/regression.test.ts
+++ b/webapp/tests/lib/client/components/features/charts/regression.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { createRegressionSeries, findBestRegression } from '$comps/features/charts/regression';
+import type { DashboardStatsValue } from '$lib/types';
+
+/**
+ * createRegressionSeries was reshaped during the Chart.js -> LayerChart migration (ES-3031):
+ * it now returns a library-agnostic { points, predict, label } series instead of a Chart.js
+ * ChartDataset. These tests pin that contract.
+ */
+
+// A clean linear relationship: value = 2 * time (so predictions are exact).
+const linearData: DashboardStatsValue[] = Array.from({ length: 10 }, (_, i) => ({
+  time: i,
+  value: i * 2,
+}));
+
+describe('createRegressionSeries', () => {
+  it('returns sorted fitted points and a working predictor for a linear fit', () => {
+    const series = createRegressionSeries({ data: linearData, type: 'linear', label: 'Trend' });
+
+    expect(series.label).toBe('Trend');
+    expect(series.points.length).toBeGreaterThan(0);
+
+    // points are sorted ascending by x (time)
+    for (let i = 1; i < series.points.length; i++) {
+      expect(series.points[i].x).toBeGreaterThanOrEqual(series.points[i - 1].x);
+    }
+
+    // predictor recovers the underlying y = 2x relationship
+    expect(series.predict(5)).toBeCloseTo(10, 5);
+    expect(series.predict(20)).toBeCloseTo(40, 5);
+  });
+
+  it('supports bestFit without an explicit type', () => {
+    const series = createRegressionSeries({ data: linearData, bestFit: true });
+    expect(series.points.length).toBeGreaterThan(0);
+    expect(series.predict(5)).toBeCloseTo(10, 1);
+  });
+
+  it('throws when neither type nor bestFit is provided', () => {
+    expect(() => createRegressionSeries({ data: linearData })).toThrow();
+  });
+
+  it('throws when both type and bestFit are provided', () => {
+    expect(() =>
+      createRegressionSeries({ data: linearData, type: 'linear', bestFit: true })
+    ).toThrow();
+  });
+});
+
+describe('findBestRegression', () => {
+  it('selects a fit with high r2 for clean linear data', () => {
+    const best = findBestRegression(linearData.map((d) => [d.time, d.value]));
+    expect(best.r2).toBeGreaterThan(0.99);
+  });
+});

--- a/webapp/tests/lib/client/components/features/charts/y-axis.test.ts
+++ b/webapp/tests/lib/client/components/features/charts/y-axis.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { scaleLog } from 'd3-scale';
-import { chartYBaseline, logSafe } from '$comps/features/charts/y-axis';
+import { chartYBaseline, logClamp, logFloor } from '$comps/features/charts/y-axis';
 
 /**
  * Regression guard for the log-axis break found during the ES-3031 visual pass.
@@ -31,33 +31,52 @@ describe('chartYBaseline', () => {
   });
 });
 
-describe('logSafe', () => {
-  it('passes values through unchanged on a linear axis (including 0 and negatives)', () => {
-    expect(logSafe(0, false)).toBe(0);
-    expect(logSafe(42, false)).toBe(42);
-    expect(logSafe(-5, false)).toBe(-5);
+describe('logFloor', () => {
+  it('returns the smallest positive value in the series', () => {
+    expect(logFloor([0, 24, 5, 80, -1, 20])).toBe(5);
   });
 
-  it('maps non-positive values to null on a log axis (0 and negatives have no log position)', () => {
+  it('ignores 0, negatives, and null/undefined', () => {
+    expect(logFloor([0, -3, null, undefined, 12])).toBe(12);
+  });
+
+  it('falls back to 1 when there is no positive value', () => {
+    expect(logFloor([0, -1, null])).toBe(1);
+    expect(logFloor([])).toBe(1);
+  });
+});
+
+describe('logClamp', () => {
+  const floor = 5;
+
+  it('passes values through unchanged on a linear axis (including 0 and negatives)', () => {
+    expect(logClamp(0, false, floor)).toBe(0);
+    expect(logClamp(42, false, floor)).toBe(42);
+    expect(logClamp(-5, false, floor)).toBe(-5);
+  });
+
+  it('raises non-positive values to the floor on a log axis (continuous, not a gap)', () => {
     // Real Bus data has 0s (empty buckets); a single 0 in a scaleLog series
-    // otherwise turns the whole path into NaN and blanks the chart.
-    expect(logSafe(0, true)).toBeNull();
-    expect(logSafe(-3, true)).toBeNull();
+    // otherwise turns the whole path into NaN and blanks the chart. Flooring
+    // (rather than nulling) keeps the line continuous, matching Chart.js.
+    expect(logClamp(0, true, floor)).toBe(floor);
+    expect(logClamp(-3, true, floor)).toBe(floor);
   });
 
   it('keeps positive values on a log axis', () => {
-    expect(logSafe(1, true)).toBe(1);
-    expect(logSafe(9999, true)).toBe(9999);
+    expect(logClamp(1, true, floor)).toBe(1);
+    expect(logClamp(9999, true, floor)).toBe(9999);
   });
 
-  it('preserves null/undefined as null on both axes', () => {
-    expect(logSafe(null, true)).toBeNull();
-    expect(logSafe(undefined, false)).toBeNull();
+  it('preserves structural null/undefined as null (deliberate gaps are not floored)', () => {
+    expect(logClamp(null, true, floor)).toBeNull();
+    expect(logClamp(undefined, false, floor)).toBeNull();
   });
 
-  it('a sanitized log series feeds scaleLog only finite numbers', () => {
+  it('a floored log series feeds scaleLog only finite numbers', () => {
     const raw = [0, 5, 0, 80, -1, 20];
-    const cleaned = raw.map((v) => logSafe(v, true)).filter((v): v is number => v != null);
+    const f = logFloor(raw);
+    const cleaned = raw.map((v) => logClamp(v, true, f)).filter((v): v is number => v != null);
     const scale = scaleLog().domain([Math.min(...cleaned), Math.max(...cleaned)]);
     for (const v of cleaned) expect(Number.isFinite(scale(v))).toBe(true);
   });

--- a/webapp/tests/lib/client/components/features/charts/y-axis.test.ts
+++ b/webapp/tests/lib/client/components/features/charts/y-axis.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { scaleLog } from 'd3-scale';
+import { chartYBaseline } from '$comps/features/charts/y-axis';
+
+/**
+ * Regression guard for the log-axis break found during the ES-3031 visual pass.
+ *
+ * Before the fix, the migrated charts left LayerChart's default y-baseline of 0
+ * in place. With a logarithmic scale that puts 0 in the domain, and log(0) is
+ * -Infinity, so every point mapped to NaN and the chart rendered nothing
+ * (`<path d="M0,NaN…">`). The fix drops the baseline (null) for the log case so
+ * the domain comes from the positive data extents, while keeping 0 for linear.
+ */
+describe('chartYBaseline', () => {
+  it('keeps the zero baseline for a linear axis (fill-to-zero parity)', () => {
+    expect(chartYBaseline(false)).toBe(0);
+  });
+
+  it('drops the baseline for a logarithmic axis so 0 stays out of the domain', () => {
+    expect(chartYBaseline(true)).toBeNull();
+  });
+
+  it('documents WHY: a log domain that includes the zero baseline yields NaN', () => {
+    // What the old code effectively did: domain [min(0, ...data), max(...data)].
+    const brokenDomain = scaleLog().domain([0, 100]);
+    expect(Number.isNaN(brokenDomain(50))).toBe(true);
+
+    // What the fix does: domain from positive data extents only.
+    const fixedDomain = scaleLog().domain([1, 100]);
+    expect(Number.isFinite(fixedDomain(50))).toBe(true);
+  });
+});

--- a/webapp/tests/lib/client/components/features/charts/y-axis.test.ts
+++ b/webapp/tests/lib/client/components/features/charts/y-axis.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { scaleLog } from 'd3-scale';
-import { chartYBaseline } from '$comps/features/charts/y-axis';
+import { chartYBaseline, logSafe } from '$comps/features/charts/y-axis';
 
 /**
  * Regression guard for the log-axis break found during the ES-3031 visual pass.
@@ -28,5 +28,37 @@ describe('chartYBaseline', () => {
     // What the fix does: domain from positive data extents only.
     const fixedDomain = scaleLog().domain([1, 100]);
     expect(Number.isFinite(fixedDomain(50))).toBe(true);
+  });
+});
+
+describe('logSafe', () => {
+  it('passes values through unchanged on a linear axis (including 0 and negatives)', () => {
+    expect(logSafe(0, false)).toBe(0);
+    expect(logSafe(42, false)).toBe(42);
+    expect(logSafe(-5, false)).toBe(-5);
+  });
+
+  it('maps non-positive values to null on a log axis (0 and negatives have no log position)', () => {
+    // Real Bus data has 0s (empty buckets); a single 0 in a scaleLog series
+    // otherwise turns the whole path into NaN and blanks the chart.
+    expect(logSafe(0, true)).toBeNull();
+    expect(logSafe(-3, true)).toBeNull();
+  });
+
+  it('keeps positive values on a log axis', () => {
+    expect(logSafe(1, true)).toBe(1);
+    expect(logSafe(9999, true)).toBe(9999);
+  });
+
+  it('preserves null/undefined as null on both axes', () => {
+    expect(logSafe(null, true)).toBeNull();
+    expect(logSafe(undefined, false)).toBeNull();
+  });
+
+  it('a sanitized log series feeds scaleLog only finite numbers', () => {
+    const raw = [0, 5, 0, 80, -1, 20];
+    const cleaned = raw.map((v) => logSafe(v, true)).filter((v): v is number => v != null);
+    const scale = scaleLog().domain([Math.min(...cleaned), Math.max(...cleaned)]);
+    for (const v of cleaned) expect(Number.isFinite(scale(v))).toBe(true);
   });
 });


### PR DESCRIPTION
_Co-authored by Claude on 2026-07-22._

## Summary
Migrate all Chart.js charts in the bus-ui webapp to LayerChart (`layerchart@2.0.0-next`) and remove `chart.js` + `chartjs-plugin-annotation`. Each chart is now a browser-guarded wrapper that lazy-loads a LayerChart `*-inner.svelte` (the proven sparkline SSR pattern). Net −366 LOC.

## Tier
Tier 2.

## Jira
- Codework: https://chb.atlassian.net/browse/ES-3031
- Epic: ES-2951 (Stage 6)

(Single ES ticket — hypothesis/brief tracked inline on ES-3031.)

## Scope
In: the five chart components under `webapp/src/lib/client/components/features/charts/` and their regression helper. Out: no changes to data sources, chart call sites (beyond re-enabling two dead ones), or unrelated components.

## What changed
- `generic-line-chart`, `generic-bucket-line-chart`, `queue-lag-chart`, `events-read-chart`, `events-in-queue-chart`: each split into an SSR-safe wrapper (layout/sidebar/options + browser-guarded lazy import) and a new `*-inner.svelte` rendering LayerChart `LineChart`/`AreaChart`.
- Annotation lines (now-line, checkpoint, last-read cutoff) via the `aboveMarks` snippet with `AnnotationLine`.
- Multi-series charts use a single merged row-per-timestamp array with per-series keys; bucket series carry the adjacent boundary point so fills reach the transition.
- `regression.ts`: `createDataSet` (returned a Chart.js `ChartDataset`) replaced by `createRegressionSeries` returning `{ points, predict, label }`; dropped the chart.js type import.
- Removed `chart.js` and `chartjs-plugin-annotation` from `webapp/package.json` + lockfile.
- `events-read-chart` / `events-in-queue-chart` were dead (render sites commented out; the latter referenced an undefined `data`); migrated per decision-log AD-002 and fixed to use their declared props so the dependency could be dropped.

## Tests / Validation
| Check | Result |
|-------|--------|
| `npm run build` (from `webapp/`) | Green |
| `npm run check` (svelte-check) | No new errors (44 total = documented baseline; none in touched files) |
| `npx vitest run tests/ --environment node` | 94 tests pass |
| New: `y-axis.test.ts` (3), plus `regression.test.ts` (5), `bucket-totals.test.ts`, `generic-bucket-line-chart.props.test.ts` | Pass |
| Visual-parity pass (Playwright headless, synthetic data harness) | Ran — see below |

**Visual-parity pass results:**
- ✅ Area fills (3-series bucket & events-in-queue) — distinct colors, ~0.5 opacity, no gaps at bucket transitions
- ✅ Annotation lines — now-line, dashed checkpoint, last-read all positioned correctly
- ✅ Linear line/area charts — fill-to-zero baseline preserved
- 🐛→✅ **Logarithmic y-axis was broken** (NaN path, no line rendered on all 3 charts with the log toggle) — root cause: LayerChart's default `yBaseline=0` puts 0 in a log domain (`log(0) = -Infinity`). **Fixed** in this PR via `chartYBaseline()`.
- 🐛→✅ **Trend line rendered solid** (original was dashed) — **fixed** via per-series `stroke-dasharray`.
- ⚠️ Tooltip header/value formatting — not exercised (headless synthetic hover doesn't trigger LayerChart's SVG overlay); low risk, worth a manual hover before/after merge.

## Rollout
Frontend-only; no migrations or config. Revert = revert the branch.

## AI Usage
Claude Code (Opus 4.8) did the migration and ran the visual-parity pass. The specific moment it changed the outcome: driving the charts headless with Playwright against a synthetic-data harness surfaced a logarithmic-axis regression (NaN path → empty chart) that the build, type-check, and unit tests all passed clean — a defect that would otherwise have shipped on a user-facing toggle. It traced the root cause to LayerChart's default zero y-baseline and fixed all three charts. (Earlier: it also caught the two "dead" `chart.js`-importing components via a downstream-import scan; decision-log AD-002.)

## Reviewers
- L1 (right thing / scope): _pending_
- L2 (correctness): _pending_

## Checklist
- [x] Code follows project style
- [x] Self-review (L1 + L2) completed
- [x] Tests added/updated
- [x] Chart.js dependency removed from package.json + lockfile
- [x] Visual parity verified (log-axis + trend-dash regressions found and fixed; tooltip formatting is the one item left for a manual hover)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large frontend chart migration across primary dashboard views; behavior is regression-tested for totals and log axes, but visual/tooltip parity still depends on manual verification.
> 
> **Overview**
> Removes **Chart.js** and **chartjs-plugin-annotation** from the webapp and reimplements the five bus dashboard charts under `features/charts/` on **LayerChart** (`LineChart` / `AreaChart`), matching the existing sparkline pattern: SSR-safe wrappers lazy-load `*-inner.svelte` only in the browser.
> 
> Each chart keeps the same sidebar totals and options (log scale, trend lines, annotations). Rendering moves to merged row-per-timestamp series, `AnnotationLine` for now/checkpoint/last-read, and shared helpers **`chartYBaseline`**, **`logClamp`**, and **`logFloor`** so logarithmic axes do not include zero (which previously produced blank charts) while linear charts still fill to zero. Bucket sidebar sums are centralized in **`computeBucketTotals`** with unit tests so aggregation windows and override precedence stay aligned with the old inline logic. **`createRegressionSeries`** replaces the Chart.js **`createDataSet`** return type for queue-lag trend lines.
> 
> **`events-read-chart`** and **`events-in-queue-chart`** are migrated and wired to their declared props (they had been dead / broken references), so Chart.js can be dropped from dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0176a4d48f0fa76c4fc81066fa1cb69fb3a6a931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->