### PR TITLE
docs(deploy): document the playground bus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-SvelteKit 2 + Svelte 5 webapp that monitors LEO Platform (serverless ETL). Deployed to AWS Lambda via SST v3 in three parallel instances: `botmonAlpha` (cup bus), `botmonAlphaChub` (chub bus), `botmonAlphaStreams` (stream bus). All instances are the same codebase — the stage name (`test-cup`, `prod-stream`, etc.) controls which DynamoDB tables and S3 bucket are targeted.
+SvelteKit 2 + Svelte 5 webapp that monitors LEO Platform (serverless ETL). Deployed to AWS Lambda via SST v3 in four parallel instances: `botmonAlpha` (cup bus), `botmonAlphaChub` (chub bus), `botmonAlphaStreams` (stream bus), and `botmonAlphaPlayground` (ad-hoc training bus, test env only). All instances are the same codebase — the stage name (`test-cup`, `prod-stream`, etc.) controls which DynamoDB tables and S3 bucket are targeted.
 
 ## Tech Stack
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-SvelteKit 2 + Svelte 5 webapp that monitors LEO Platform (serverless ETL). Deployed to AWS Lambda via SST v3 in four parallel instances: `botmonAlpha` (cup bus), `botmonAlphaChub` (chub bus), `botmonAlphaStreams` (stream bus), and `botmonAlphaPlayground` (ad-hoc training bus, test env only). All instances are the same codebase — the stage name (`test-cup`, `prod-stream`, etc.) controls which DynamoDB tables and S3 bucket are targeted.
+SvelteKit 2 + Svelte 5 webapp that monitors LEO Platform (serverless ETL). Deployed to AWS Lambda via SST v4 in four parallel instances: `botmonAlpha` (cup bus), `botmonAlphaChub` (chub bus), `botmonAlphaStreams` (stream bus), and `botmonAlphaPlayground` (ad-hoc training bus, test env only). All instances are the same codebase — the stage name (`test-cup`, `prod-stream`, etc.) controls which DynamoDB tables and S3 bucket are targeted.
 
 ## Tech Stack
 

--- a/webapp/DEPLOYMENT.md
+++ b/webapp/DEPLOYMENT.md
@@ -56,14 +56,24 @@ The SvelteKit webapp deploys to AWS as **Lambda (SSR) + CloudFront (CDN) + S3 (s
 
 If the `{Env}{Bus}Botmon` stack doesn't exist (no old-Botmon), the deploy fails hard — it won't create a new LeoStats. Create one out-of-band before first deploy.
 
+The `playground` bus is the one exception to convention-based naming — see [Ad-hoc bus overrides](#ad-hoc-bus-overrides).
+
 ## Stage naming
 
 `{env}-{bus}` — matches the `create-env` npm scripts:
 
 - `env` ∈ `test`, `staging`, `prod`
-- `bus` ∈ `cup`, `chub`, `stream` (`cup` is the default bus; no suffix in AWS resource names)
+- `bus` ∈ `cup`, `chub`, `stream`, `playground` (`cup` is the default bus; no suffix in AWS resource names)
 
-Examples: `test-cup`, `staging-chub`, `prod-stream`.
+Examples: `test-cup`, `staging-chub`, `prod-stream`, `test-playground`.
+
+**`playground` is test-only.** It is a single ad-hoc training bus that exists in the test
+environment and nowhere else. `parseStage` rejects any other combination:
+
+```
+Invalid stage "staging-playground". The playground bus only exists in the test
+environment — use "test-playground".
+```
 
 The API Gateway base path also varies per bus:
 
@@ -72,16 +82,18 @@ The API Gateway base path also varies per bus:
 | cup | `botmonAlpha` |
 | chub | `botmonAlphaChub` |
 | stream | `botmonAlphaStreams` |
+| playground | `botmonAlphaPlayground` |
 
 ## Live stages
 
-All nine stages are currently deployed:
+All ten stages are currently deployed:
 
 | Stage | URL |
 |---|---|
 | test-cup | https://test-apps.dsco.io/botmonAlpha |
 | test-chub | https://test-apps.dsco.io/botmonAlphaChub |
 | test-stream | https://test-apps.dsco.io/botmonAlphaStreams |
+| test-playground | https://test-apps.dsco.io/botmonAlphaPlayground |
 | staging-cup | https://staging-apps.dsco.io/botmonAlpha |
 | staging-chub | https://staging-apps.dsco.io/botmonAlphaChub |
 | staging-stream | https://staging-apps.dsco.io/botmonAlphaStreams |
@@ -138,6 +150,27 @@ Most environment variables are resolved **automatically at deploy time** — no 
 | `AWS_REGION` | From Bus secret or defaults to `us-east-1` |
 
 If a value is missing (wrong region, stack not deployed, IAM missing), the deploy fails with a clear error. See [`sst.config.ts`](./sst.config.ts) resource-discovery helpers around lines 100-270.
+
+### Ad-hoc bus overrides
+
+`cup`, `chub`, and `stream` all follow the `{Env}{Bus}` naming convention, so their resources are
+discovered automatically. **PlaygroundBus was deployed ad-hoc** — its physical names are
+`PlaygroundBus-*` with no env prefix, so convention-based discovery misses. The exceptions are
+mapped explicitly in the `BUS_OVERRIDES` table in [`sst.config.ts`](./sst.config.ts):
+
+| | Convention (`cup`/`chub`/`stream`) | `playground` |
+|---|---|---|
+| Bus secret | `rstreams-{Env}{Bus}Bus` | `rstreams-PlaygroundBus` |
+| Botmon CFN stack (LeoStats source) | `{Env}{Bus}Botmon` | `PlaygroundBus-Botmon-HWSMESWEJX0K` |
+| BasePathMapping key | `botmonAlpha[Bus]` | `botmonAlphaPlayground` |
+
+`LEO_AUTH_USER_TABLE_NAME` is deliberately **not** overridden — playground resolves it through the
+standard `/mcd/test/rstreams/main_bus/leo_auth_user_table_name` path to the shared TestAuth table.
+That table is auto-populated from the test DSCO identity pool that playground logins authenticate
+against, so trainee identities resolve without per-user maintenance.
+
+If the playground stack is ever rebuilt, the CloudFormation stack name (including its random
+suffix) changes and `BUS_OVERRIDES` must be updated to match.
 
 ## API Gateway v1 REST API
 


### PR DESCRIPTION
## Summary

`DEPLOYMENT.md` documented only `cup`, `chub`, and `stream` and listed nine live stages, but `sst.config.ts` has supported `test-playground` since `b75e141`. This documents the playground bus.

## Changes

- **Stage naming** — added `playground` to the valid buses, including the test-only constraint and the exact error `parseStage` raises for any other environment.
- **BasePathMapping table** — added `playground` → `botmonAlphaPlayground`.
- **Live stages table** — added `test-playground`; nine → ten.
- **New "Ad-hoc bus overrides" section** — documents the `BUS_OVERRIDES` exceptions (`rstreams-PlaygroundBus`, `PlaygroundBus-Botmon-HWSMESWEJX0K`, `botmonAlphaPlayground`) and why `LEO_AUTH_USER_TABLE_NAME` is deliberately *not* overridden: it resolves through the standard `/mcd/test/...` path to the shared TestAuth table, which is auto-populated from the test DSCO identity pool that playground logins authenticate against.
- Noted that a playground rebuild changes the CloudFormation stack's random suffix, so `BUS_OVERRIDES` must be updated to match.
- **`AGENTS.md`** — corrected "three parallel instances" to four, and the SST major to v4.

## Testing

Documentation only. Values verified against `sst.config.ts` and `scripts/create-env.ts` rather than copied from prose, and `https://test-apps.dsco.io/botmonAlphaPlayground` confirmed live (302).

## Notes

No Jira ticket. Overlaps slightly with the SST v4 toolchain PR, which also touches `DEPLOYMENT.md` and `AGENTS.md` in different sections — whichever merges second may need a trivial rebase.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [ ] Tests added/updated — n/a, docs only
- [x] Documentation updated
- [ ] Version bump — n/a, nothing ships in the deployed app

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes with no runtime, deploy, or auth code modifications.
> 
> **Overview**
> **Documentation-only** updates so deploy docs match existing `test-playground` support in `sst.config.ts`.
> 
> **`AGENTS.md`** now lists **four** parallel Botmon instances (adds `botmonAlphaPlayground`) and bumps the stated SST major version to **v4** in the overview.
> 
> **`webapp/DEPLOYMENT.md`** expands stage naming to include **`playground`** (test-only), documents the **`parseStage`** error for non-test playground stages, adds **`botmonAlphaPlayground`** to the BasePathMapping table, and grows the live stages list from nine to ten with **`test-playground`**. A new **Ad-hoc bus overrides** section explains **`BUS_OVERRIDES`** for PlaygroundBus (secret, Botmon CFN stack, API key) and why **`LEO_AUTH_USER_TABLE_NAME`** stays on the shared TestAuth path, plus a note that rebuilding playground requires updating the CFN stack name in overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ca4c6628d45cdd742c6c8e83078d55243fafb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->