### PR TITLE
ES-3461 botmonAlpha: checkpoint calendar picker, stale checkpoint display, unreachable rogue status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,25 @@ npm run dev         # Vite dev server (localhost:5173)
 npm run check       # svelte-check type check
 npm run lint        # ESLint
 npm test            # Vitest
+npm run dev:mock    # Vite dev server against the in-memory mock bus (no AWS)
 ```
 
 Setup: `cp providers.config.example.json providers.config.json` then `npm run create-env-test-cup` to generate `.env.local`.
+
+`npm test` runs two Vitest projects (`vitest.workspace.ts`): `botmon` for node logic tests under
+`tests/`, and `storybook` for `*.stories.svelte` executed in real chromium via
+`@storybook/experimental-addon-test`. The browser project needs `npx playwright install` and both
+`.storybook/preview.ts` and `.storybook/vitest.setup.ts` — the setup file is named in
+`vitest.workspace.ts`, and if it is missing every story suite fails with `Failed to fetch
+dynamically imported module` rather than a readable error. For node-only logic tests, skip the
+browser entirely with `npx vitest run --project botmon`.
+
+`@storybook/addon-svelte-csf` resolves to a Storybook-9 prerelease (`^5.0.0-next.0`, locked at
+`5.0.0-next.28`) while the rest of Storybook is on 8.6. That prerelease reads
+`parameters.__svelteCsf.rawCode` under the Vitest runner and throws when it is absent;
+`.storybook/preview.ts` supplies a `__svelteCsf: {}` default to work around it. Aligning the addon
+with Storybook 8.6 is the real fix. Mock bots and the dev-only mock bus are documented in
+`webapp/src/lib/testing/README.md`.
 
 ## Key Patterns
 

--- a/webapp/.storybook/preview.ts
+++ b/webapp/.storybook/preview.ts
@@ -1,0 +1,19 @@
+import type { Preview } from '@storybook/svelte';
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    // addon-svelte-csf's source-snippet effect reads `parameters.__svelteCsf.rawCode`. Under
+    // the vitest storybook (browser) runner the csf source metadata isn't injected, so that
+    // read throws during render. Defaulting `__svelteCsf` here makes the effect skip source
+    // emission (rawCode is undefined) instead of crashing, so the play tests can run.
+    __svelteCsf: {},
+  },
+};
+
+export default preview;

--- a/webapp/.storybook/vitest.setup.ts
+++ b/webapp/.storybook/vitest.setup.ts
@@ -1,0 +1,9 @@
+import { beforeAll } from 'vitest';
+import { setProjectAnnotations } from '@storybook/sveltekit';
+import * as projectAnnotations from './preview';
+
+// Applies Storybook's project-level annotations (from .storybook/preview) to the portable
+// stories the vitest storybook project runs in the browser. Referenced by vitest.workspace.ts.
+const project = setProjectAnnotations([projectAnnotations]);
+
+beforeAll(project.beforeAll);

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
+    "dev:mock": "LOCAL=true MOCK_BUS=1 AUTH_SECRET=dev-mock-secret AWS_ACCESS_KEY_ID=mock AWS_SECRET_ACCESS_KEY=mock AWS_REGION=us-east-1 vite dev",
     "build": "vite build",
     "preview": "vite preview",
     "prepare": "svelte-kit sync || echo ''",

--- a/webapp/src/lib/client/components/copy-button.stories.svelte
+++ b/webapp/src/lib/client/components/copy-button.stories.svelte
@@ -1,0 +1,90 @@
+<!--
+  copy-button.stories — regression coverage for ES-3461 issue 2.
+
+  The dashboard header renders the current read checkpoint through CopyButton. Saving a new
+  checkpoint changes that value in place, so CopyButton must re-render the new text. It did
+  not: the component scraped its text out of a hidden <pre> inside an $effect whose only
+  dependency was the `children` snippet reference, which never changes — so the first value
+  was captured on mount and the header kept showing the pre-save token until a full reload.
+
+  The `play` functions run as browser tests via the Storybook vitest project.
+-->
+<script module lang="ts">
+  import { defineMeta, setTemplate, type Args } from '@storybook/addon-svelte-csf';
+  import { expect } from '@storybook/test';
+  import CopyButtonHarness from '$lib/testing/copy-button-harness.svelte';
+  import type { ComponentProps } from 'svelte';
+
+  const { Story } = defineMeta({
+    title: 'Botmon/CopyButton',
+    component: CopyButtonHarness,
+  });
+
+  const OLD_TOKEN = 'z/2023/04/26/16/59/1682528369063-0000000';
+  const NEW_TOKEN = 'z/2026/08/17/18/30/00/';
+
+  /** The visible (non-hidden) text CopyButton paints. */
+  function shownText(canvasElement: HTMLElement): string {
+    const span = canvasElement.querySelector('span.font-mono');
+    return (span?.textContent ?? '').trim();
+  }
+
+  /**
+   * Poll the visible text until it equals `expected`, then assert. Polling rather than a fixed
+   * tick keeps the passing case non-flaky (the value arrives asynchronously) while still failing
+   * on the regression — a value that never updates simply exhausts the budget.
+   */
+  async function expectText(canvasElement: HTMLElement, expected: string): Promise<void> {
+    const deadline = Date.now() + 1500;
+    while (shownText(canvasElement) !== expected && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    await expect(shownText(canvasElement)).toBe(expected);
+  }
+
+  async function clickSwap(canvasElement: HTMLElement): Promise<void> {
+    const button = canvasElement.querySelector('[data-testid="swap"]') as HTMLButtonElement | null;
+    await expect(button).toBeTruthy();
+    button!.click();
+  }
+</script>
+
+<script lang="ts">
+  setTemplate(template);
+</script>
+
+{#snippet template(args: Args<typeof Story>)}
+  <CopyButtonHarness {...(args as ComponentProps<typeof CopyButtonHarness>)} />
+{/snippet}
+
+<Story
+  name="Shows the initial value"
+  args={{ first: OLD_TOKEN, second: NEW_TOKEN }}
+  play={async ({ canvasElement }) => {
+    await expectText(canvasElement, OLD_TOKEN);
+  }}
+/>
+
+<Story
+  name="Follows the value when it changes after mount"
+  args={{ first: OLD_TOKEN, second: NEW_TOKEN }}
+  play={async ({ canvasElement }) => {
+    await expectText(canvasElement, OLD_TOKEN);
+    await clickSwap(canvasElement);
+    // The regression: this stayed on OLD_TOKEN, which is why the dashboard header kept
+    // showing the pre-save checkpoint until the page was reloaded.
+    await expectText(canvasElement, NEW_TOKEN);
+  }}
+/>
+
+<Story
+  name="Truncates, and re-truncates the new value"
+  args={{ first: OLD_TOKEN, second: NEW_TOKEN, truncate: true, maxLength: 25 }}
+  play={async ({ canvasElement }) => {
+    // OLD_TOKEN is 40 chars, so it truncates; NEW_TOKEN is 22, so it comes through whole.
+    // Both halves matter: truncation has to be recomputed for the new value, not carried over.
+    await expectText(canvasElement, OLD_TOKEN.substring(0, 25) + '...');
+    await clickSwap(canvasElement);
+    await expectText(canvasElement, NEW_TOKEN);
+  }}
+/>

--- a/webapp/src/lib/client/components/copy-button.svelte
+++ b/webapp/src/lib/client/components/copy-button.svelte
@@ -1,18 +1,26 @@
+<!--
+  CopyButton — renders a value as monospace text with a copy-to-clipboard affordance.
+
+  The value is taken as a plain `value` prop rather than as a snippet whose rendered text is
+  scraped out of a hidden element. The scrape version could not react to its own content: the
+  extraction ran inside an $effect whose only dependency was the `children` snippet reference,
+  which is stable across updates, so the text was captured once on mount. Any caller whose value
+  changed in place — the dashboard header after a checkpoint save (ES-3461 issue 2) — kept
+  displaying the mount-time value until a full page reload.
+-->
 <script lang="ts">
     import { Check, Copy } from "@lucide/svelte";
     import { Button } from "$ui/button";
-    import { tick, type Snippet } from "svelte";
 
     type CopyButtonProps = {
-        children?: Snippet<[]>;
+        /** Text to display and to place on the clipboard. Reactive — updates in place. */
+        value: string | undefined;
         truncate?: boolean;
         maxLength?: number;
     }
 
-    let {children, truncate = false, maxLength = 30}: CopyButtonProps = $props();
+    let {value, truncate = false, maxLength = 30}: CopyButtonProps = $props();
 
-    let hiddenRef: HTMLElement;
-    let value: string | undefined = $state(undefined);
     let displayValue: string | undefined = $derived.by(() => {
         if (!value) return undefined;
         if (truncate && value.length > maxLength) {
@@ -21,27 +29,6 @@
         return value;
     });
     let showCheckmark = $state(false);
-
-    $effect(() => {
-        if (children) {
-            extractText().catch((e) => {
-                throw new Error(
-                    `Failed to extract value: ${e instanceof Error ? e.message + ' ' + e.stack : String(e)}`
-                );
-            });
-        }
-    });
-
-    async function extractText() {
-        await tick();
-        if(hiddenRef) {
-            value = (hiddenRef.textContent || '').trim();
-        }
-
-        if(!value) {
-            throw new Error('Did not find any text in the hidden container of ValueToCopy');
-        }
-    }
 
     function copy() {
         if (!value) {
@@ -68,20 +55,15 @@
 
 </script>
 
-<pre
-    class="hidden-container"
-    bind:this={hiddenRef}
-    style="display: none; position: absolute; left: -9999px;">{#if children}{@render children()}{/if}</pre>
-
-    <span class="inline-flex w-fit items-center gap-1">
-        <span class="text-sm font-mono text-muted-foreground" title={truncate ? value : undefined}>{displayValue}</span>
-        <span class="w-6 h-6 flex items-center justify-center">
-            {#if showCheckmark}
-                <Check class="w-3.5 h-3.5 text-green-500" />
-            {:else}
-                <Button variant="ghost" class="h-full w-full min-h-0 p-0 rounded-none hover:bg-transparent" onclick={copy} disabled={!value}>
-                    <Copy class="w-3.5 h-3.5 text-gray-400 hover:text-foreground transition-colors" />
-                </Button>
-            {/if}
-        </span>
+<span class="inline-flex w-fit items-center gap-1">
+    <span class="text-sm font-mono text-muted-foreground" title={truncate ? value : undefined}>{displayValue}</span>
+    <span class="w-6 h-6 flex items-center justify-center">
+        {#if showCheckmark}
+            <Check class="w-3.5 h-3.5 text-green-500" />
+        {:else}
+            <Button variant="ghost" class="h-full w-full min-h-0 p-0 rounded-none hover:bg-transparent" onclick={copy} disabled={!value}>
+                <Copy class="w-3.5 h-3.5 text-gray-400 hover:text-foreground transition-colors" />
+            </Button>
+        {/if}
     </span>
+</span>

--- a/webapp/src/lib/client/components/features/bot-table/bot-table-name-cell.stories.svelte
+++ b/webapp/src/lib/client/components/features/bot-table/bot-table-name-cell.stories.svelte
@@ -1,0 +1,135 @@
+<!--
+  bot-table-name-cell.stories — the visual half of the ES-3461 test infrastructure.
+
+  One story per mock-bot preset. Each story computes the bot's status through the SAME
+  evaluateBotStatus logic the app uses, then renders the catalog name cell. The `play`
+  functions turn each story into a browser test (via the Storybook vitest project) that
+  asserts the status ring the cell paints on the icon <img>.
+-->
+<script module lang="ts">
+  import { defineMeta, setTemplate, type Args } from '@storybook/addon-svelte-csf';
+  import { expect } from '@storybook/test';
+  import NameCell from './bot-table-name-cell.svelte';
+  import StoryAppState from '$lib/testing/story-appstate.svelte';
+  import { evaluateBotStatus } from '$comps/features/bot/bot-status.utils';
+  import {
+    mockHealthy,
+    mockRogue,
+    mockRoguePaused,
+    mockPaused,
+    mockArchivedRogue,
+    mockBlocked,
+    mockDanger,
+    mockCheckpoint,
+    mockStatsFor,
+  } from '$lib/testing/mock-bots';
+  import type { ComponentProps } from 'svelte';
+  import type { BotSettings } from '$lib/types';
+
+  const { Story } = defineMeta({
+    title: 'Botmon/BotTableNameCell',
+    component: NameCell,
+  });
+
+  /** Build the cell args for a preset, deriving status the way the real table does. */
+  function cellArgs(preset: BotSettings) {
+    return {
+      id: preset.id,
+      name: preset.name ?? preset.id,
+      tags: preset.tags,
+      kind: 'bot' as const,
+      status: evaluateBotStatus(preset, mockStatsFor(preset.id)).status,
+    };
+  }
+
+  /** Return the icon <img>'s class attribute, failing the test if it's missing. */
+  async function imgClass(canvasElement: HTMLElement): Promise<string> {
+    const img = canvasElement.querySelector('img');
+    await expect(img).toBeTruthy();
+    return img?.getAttribute('class') ?? '';
+  }
+
+  const RING_TOKENS = ['ring-red-500', 'ring-amber-500', 'ring-gray-500', 'opacity-60', 'opacity-40'];
+</script>
+
+<script lang="ts">
+  // Must be in the instance script: setTemplate references the markup snippet below.
+  setTemplate(template);
+</script>
+
+{#snippet template(args: Args<typeof Story>)}
+  <StoryAppState>
+    <NameCell {...(args as ComponentProps<typeof NameCell>)} />
+  </StoryAppState>
+{/snippet}
+
+<Story
+  name="Healthy"
+  args={cellArgs(mockHealthy())}
+  play={async ({ canvasElement }) => {
+    const cls = await imgClass(canvasElement);
+    for (const token of RING_TOKENS) expect(cls).not.toContain(token);
+  }}
+/>
+
+<Story
+  name="Rogue"
+  args={cellArgs(mockRogue())}
+  play={async ({ canvasElement }) => {
+    expect(await imgClass(canvasElement)).toContain('ring-red-500');
+  }}
+/>
+
+<Story
+  name="RoguePaused"
+  args={cellArgs(mockRoguePaused())}
+  play={async ({ canvasElement }) => {
+    // Rogue wins over paused → red ring, not the gray paused ring.
+    expect(await imgClass(canvasElement)).toContain('ring-red-500');
+  }}
+/>
+
+<Story
+  name="Paused"
+  args={cellArgs(mockPaused())}
+  play={async ({ canvasElement }) => {
+    const cls = await imgClass(canvasElement);
+    expect(cls).toContain('ring-gray-500');
+    expect(cls).toContain('opacity-60');
+  }}
+/>
+
+<Story
+  name="ArchivedRogue"
+  args={cellArgs(mockArchivedRogue())}
+  play={async ({ canvasElement }) => {
+    // Archived wins over rogue → dimmed, no ring.
+    expect(await imgClass(canvasElement)).toContain('opacity-40');
+  }}
+/>
+
+<Story
+  name="Blocked"
+  args={cellArgs(mockBlocked())}
+  play={async ({ canvasElement }) => {
+    expect(await imgClass(canvasElement)).toContain('ring-red-500');
+  }}
+/>
+
+<Story
+  name="Danger"
+  args={cellArgs(mockDanger())}
+  play={async ({ canvasElement }) => {
+    expect(await imgClass(canvasElement)).toContain('ring-amber-500');
+  }}
+/>
+
+<Story
+  name="Checkpoint"
+  args={cellArgs(mockCheckpoint())}
+  play={async ({ canvasElement }) => {
+    // Checkpoint bot is healthy/running → no status ring.
+    const cls = await imgClass(canvasElement);
+    for (const token of RING_TOKENS) expect(cls).not.toContain(token);
+  }}
+/>

--- a/webapp/src/lib/client/components/features/bot/bot-status.utils.ts
+++ b/webapp/src/lib/client/components/features/bot/bot-status.utils.ts
@@ -17,11 +17,27 @@ export function evaluateBotStatus(
   let status: BotStatus = 'running';
   let isAlarmed = false;
   let alarms: BotAlarms = {};
-  let rogue = false;
 
-  // If no stats available, return default values
+  // 1. Check if bot is ROGUE.
+  //    Match the legacy bus-ui behavior (old_ui/lib/stats.js): rogue is driven by the
+  //    persisted consecutive-error counter on the cron record (reset to 0 on force-run /
+  //    success), NOT by errors summed over the currently-viewed stats window. This keeps
+  //    rogue a sticky "needs intervention until cleared" state that doesn't disappear when
+  //    the operator narrows the time range — or when the bot has no stats in the window.
+  //    Evaluate it BEFORE the no-stats short-circuit so a quiet rogue bot still shows rogue.
+  const persistedErrorCount = bot.errorCount ?? 0;
+  const rogue = persistedErrorCount > BOT_STATUS_DEFAULTS.ROGUE_ERROR_THRESHOLD;
+  if (rogue) {
+    status = 'rogue';
+  }
+
+  // If no stats available, we can't compute lag/error-rate alarms, but the record alone
+  // still tells us rogue / paused / archived — apply those and return.
   if (!stats) {
-    return { status, isAlarmed, alarms, rogue, errorCount: 0, errorRate: 0, writeLag: 0, sourceLag: 0 };
+    return {
+      status: applyManualStates(bot, status, rogue, isAlarmed),
+      isAlarmed, alarms, rogue, errorCount: 0, errorRate: 0, writeLag: 0, sourceLag: 0,
+    };
   }
 
   // Calculate error statistics from raw stats
@@ -33,22 +49,10 @@ export function evaluateBotStatus(
   const writeLag = calculateWriteLag(stats);
   const sourceLag = calculateSourceLag(stats);
 
-  // 1. Check if bot is ROGUE.
-  //    Match the legacy bus-ui behavior (old_ui/lib/stats.js): rogue is driven by the
-  //    persisted consecutive-error counter on the cron record (reset to 0 on force-run /
-  //    success), NOT by errors summed over the currently-viewed stats window. This keeps
-  //    rogue a sticky "needs intervention until cleared" state that doesn't disappear when
-  //    the operator narrows the time range.
-  const persistedErrorCount = bot.errorCount ?? 0;
-  if (persistedErrorCount > BOT_STATUS_DEFAULTS.ROGUE_ERROR_THRESHOLD) {
-    rogue = true;
-    status = 'rogue';
-  }
-
   // 2. Check if bot is BLOCKED (has current errors).
   //    Rogue is the more severe error state, so only fall back to BLOCKED when the bot
   //    isn't rogue — otherwise the rogue status set above would be clobbered here.
-  else if (hasCurrentErrors(stats)) {
+  if (!rogue && hasCurrentErrors(stats)) {
     status = 'blocked';
   }
 
@@ -84,18 +88,8 @@ export function evaluateBotStatus(
     };
   }
 
-  // 4. Override with manual states.
-  //    A rogue bot stays 'rogue' even when paused — the legacy UI surfaced rogue over a
-  //    paused state so operators can still see a paused bot that went bad. Archived is the
-  //    one exception (an archived bot is intentionally decommissioned; the old UI didn't
-  //    process archived bots for rogue at all).
-  if (bot.archived) {
-    status = 'archived';
-  } else if (bot.paused && !rogue) {
-    status = 'paused';
-  } else if (isAlarmed && (status === 'running' || status === 'paused')) {
-    status = 'danger';
-  }
+  // 4. Override with manual states (archived / paused / danger).
+  status = applyManualStates(bot, status, rogue, isAlarmed);
 
   return {
     status,
@@ -107,6 +101,27 @@ export function evaluateBotStatus(
     writeLag,
     sourceLag,
   };
+}
+
+/**
+ * Apply the manual/terminal status overrides (archived / paused / danger) on top of the
+ * error-derived status. Shared by the no-stats path and the full evaluation so the two
+ * can't drift.
+ *
+ * Precedence matches legacy bus-ui (old_ui/stores/dataStore.js): archived wins outright;
+ * a rogue bot stays rogue even when paused (so a paused bot that went bad is still visible);
+ * a non-rogue paused bot shows paused; and an alarmed running/paused bot escalates to danger.
+ */
+function applyManualStates(
+  bot: BotSettings,
+  status: BotStatus,
+  rogue: boolean,
+  isAlarmed: boolean,
+): BotStatus {
+  if (bot.archived) return 'archived';
+  if (bot.paused && !rogue) return 'paused';
+  if (isAlarmed && (status === 'running' || status === 'paused')) return 'danger';
+  return status;
 }
 
 // Helper functions to extract values from raw stats

--- a/webapp/src/lib/client/components/features/bot/bot-status.utils.ts
+++ b/webapp/src/lib/client/components/features/bot/bot-status.utils.ts
@@ -39,8 +39,11 @@ export function evaluateBotStatus(
     status = 'rogue';
   }
 
-  // 2. Check if bot is BLOCKED (has current errors)
-  if (hasCurrentErrors(stats)) {
+  // 2. Check if bot is BLOCKED (has current errors).
+  //    Rogue is the more severe error state and already implies errors > 0,
+  //    so only fall back to BLOCKED when the bot isn't rogue — otherwise the
+  //    rogue status set above would always be clobbered here.
+  else if (hasCurrentErrors(stats)) {
     status = 'blocked';
   }
 

--- a/webapp/src/lib/client/components/features/bot/bot-status.utils.ts
+++ b/webapp/src/lib/client/components/features/bot/bot-status.utils.ts
@@ -33,16 +33,21 @@ export function evaluateBotStatus(
   const writeLag = calculateWriteLag(stats);
   const sourceLag = calculateSourceLag(stats);
 
-  // 1. Check if bot is ROGUE (>10 errors)
-  if (errorCount > BOT_STATUS_DEFAULTS.ROGUE_ERROR_THRESHOLD) {
+  // 1. Check if bot is ROGUE.
+  //    Match the legacy bus-ui behavior (old_ui/lib/stats.js): rogue is driven by the
+  //    persisted consecutive-error counter on the cron record (reset to 0 on force-run /
+  //    success), NOT by errors summed over the currently-viewed stats window. This keeps
+  //    rogue a sticky "needs intervention until cleared" state that doesn't disappear when
+  //    the operator narrows the time range.
+  const persistedErrorCount = bot.errorCount ?? 0;
+  if (persistedErrorCount > BOT_STATUS_DEFAULTS.ROGUE_ERROR_THRESHOLD) {
     rogue = true;
     status = 'rogue';
   }
 
   // 2. Check if bot is BLOCKED (has current errors).
-  //    Rogue is the more severe error state and already implies errors > 0,
-  //    so only fall back to BLOCKED when the bot isn't rogue — otherwise the
-  //    rogue status set above would always be clobbered here.
+  //    Rogue is the more severe error state, so only fall back to BLOCKED when the bot
+  //    isn't rogue — otherwise the rogue status set above would be clobbered here.
   else if (hasCurrentErrors(stats)) {
     status = 'blocked';
   }
@@ -79,10 +84,14 @@ export function evaluateBotStatus(
     };
   }
 
-  // 4. Override with manual states
+  // 4. Override with manual states.
+  //    A rogue bot stays 'rogue' even when paused — the legacy UI surfaced rogue over a
+  //    paused state so operators can still see a paused bot that went bad. Archived is the
+  //    one exception (an archived bot is intentionally decommissioned; the old UI didn't
+  //    process archived bots for rogue at all).
   if (bot.archived) {
     status = 'archived';
-  } else if (bot.paused) {
+  } else if (bot.paused && !rogue) {
     status = 'paused';
   } else if (isAlarmed && (status === 'running' || status === 'paused')) {
     status = 'danger';

--- a/webapp/src/lib/client/components/features/bot/bot.state.svelte.ts
+++ b/webapp/src/lib/client/components/features/bot/bot.state.svelte.ts
@@ -106,7 +106,7 @@ export class BotState {
           source_lag: (b as any).computedSourceLag || b.health?.source_lag,
           write_lag: (b as any).computedWriteLag || b.health?.write_lag,
         },
-        errorCount: b.errorCount,
+        errorCount: (b as any).computedErrorCount ?? b.errorCount,
         lambdaName: b.lambdaName,
         status: b.status,
         isAlarmed: b.isAlarmed,
@@ -477,8 +477,11 @@ export class BotState {
       bot.alarms = statusEvaluation.alarms;
       bot.rogue = statusEvaluation.rogue;
       bot.alarmed = statusEvaluation.isAlarmed;
-      bot.errorCount = statusEvaluation.errorCount;
-      // Store computed lag values so the catalog/home table can display them
+      // Store window-derived values on `computed*` fields (mirrors the lag values below)
+      // rather than overwriting the persisted `bot.errorCount`. Rogue is driven by the
+      // persisted counter, and a stats-only refresh re-runs this without re-fetching bot
+      // settings — clobbering bot.errorCount here would corrupt the rogue signal.
+      (bot as any).computedErrorCount = statusEvaluation.errorCount;
       (bot as any).computedSourceLag = statusEvaluation.sourceLag;
       (bot as any).computedWriteLag = statusEvaluation.writeLag;
     }

--- a/webapp/src/lib/client/components/features/dashboard/checkpoint-action-bar.svelte
+++ b/webapp/src/lib/client/components/features/dashboard/checkpoint-action-bar.svelte
@@ -15,6 +15,14 @@
     import { Label } from "$ui/label";
     import Input from "$ui/input/input.svelte";
     import CopyButton from "$comps/copy-button.svelte";
+    import Calendar from "$ui/calendar/calendar.svelte";
+    import { CalendarDate, type DateValue } from "@internationalized/date";
+    import Clock2Icon from "@lucide/svelte/icons/clock-2";
+    import {
+        BEGINNING_CHECKPOINT_TOKEN,
+        nowCheckpointToken,
+        checkpointTokenFromDateTime,
+    } from "./checkpoint-token";
 
     type CheckpointActionBarProps = {
         currentCheckpoint?: string;
@@ -39,6 +47,9 @@
     let selectedQueue = $state<string>("");
     let checkpointPreset = $state<string>("now");
     let customCheckpoint = $state("");
+    // Calendar picker state (interpreted as UTC — see checkpoint-token.ts).
+    let selectedDate = $state<DateValue | undefined>(undefined);
+    let selectedTime = $state("00:00:00");
 
     // Read queues from settings for the source queue selector
     let readQueues = $derived.by(() => {
@@ -60,13 +71,12 @@
 
     function computeCheckpointValue(): string {
         switch (checkpointPreset) {
-            case "now": {
-                const d = new Date();
-                const pad = (n: number) => String(n).padStart(2, '0');
-                return `z/${d.getUTCFullYear()}/${pad(d.getUTCMonth() + 1)}/${pad(d.getUTCDate())}/${pad(d.getUTCHours())}/${pad(d.getUTCMinutes())}/${pad(d.getUTCSeconds())}/`;
-            }
+            case "now":
+                return nowCheckpointToken();
             case "beginning":
-                return "z/";
+                return BEGINNING_CHECKPOINT_TOKEN;
+            case "datetime":
+                return checkpointTokenFromDateTime(selectedDate, selectedTime) ?? "";
             case "custom":
                 return customCheckpoint;
             default:
@@ -104,6 +114,12 @@
         checkpointSaving = false;
         checkpointPreset = "now";
         customCheckpoint = "";
+        // Pre-fill the calendar picker with the current UTC date/time so switching
+        // to "Pick date & time" starts from now (tokens are UTC — see checkpoint-token.ts).
+        const d = new Date();
+        selectedDate = new CalendarDate(d.getUTCFullYear(), d.getUTCMonth() + 1, d.getUTCDate());
+        const pad = (n: number) => String(n).padStart(2, "0");
+        selectedTime = `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`;
         // Re-select first queue if none selected
         if (!selectedQueue && readQueues.length > 0) {
             selectedQueue = readQueues[0];
@@ -119,6 +135,10 @@
         const value = computeCheckpointValue();
         if (checkpointPreset === "custom" && !value) {
             checkpointError = "Please enter a checkpoint value";
+            return;
+        }
+        if (checkpointPreset === "datetime" && !value) {
+            checkpointError = "Please pick a valid date and time";
             return;
         }
 
@@ -244,6 +264,8 @@
                                 Start from Now
                             {:else if checkpointPreset === 'beginning'}
                                 From the Beginning of Time
+                            {:else if checkpointPreset === 'datetime'}
+                                Pick date &amp; time
                             {:else}
                                 Custom Value
                             {/if}
@@ -251,10 +273,39 @@
                         <Select.Content>
                             <Select.Item value="now">Start from Now</Select.Item>
                             <Select.Item value="beginning">From the Beginning of Time</Select.Item>
+                            <Select.Item value="datetime">Pick date &amp; time</Select.Item>
                             <Select.Item value="custom">Custom Value</Select.Item>
                         </Select.Content>
                     </Select.Root>
                 </div>
+
+                <!-- Date + Time Picker -->
+                {#if checkpointPreset === 'datetime'}
+                    <div class="flex flex-col gap-3">
+                        <Calendar
+                            type="single"
+                            bind:value={selectedDate}
+                            class="rounded-md border bg-transparent p-2 w-fit self-center"
+                            captionLayout="dropdown"
+                        />
+                        <div class="flex flex-col gap-2">
+                            <Label for="checkpoint-time">Time (UTC)</Label>
+                            <div class="relative flex items-center">
+                                <Clock2Icon class="text-muted-foreground pointer-events-none absolute left-2.5 size-4" />
+                                <Input
+                                    id="checkpoint-time"
+                                    type="time"
+                                    step="1"
+                                    bind:value={selectedTime}
+                                    class="pl-8 font-mono text-sm appearance-none [&::-webkit-calendar-picker-indicator]:hidden"
+                                />
+                            </div>
+                        </div>
+                        <p class="text-xs text-muted-foreground font-mono break-all">
+                            {computeCheckpointValue() || 'Select a date and time'}
+                        </p>
+                    </div>
+                {/if}
 
                 <!-- Custom Checkpoint Input -->
                 {#if checkpointPreset === 'custom'}

--- a/webapp/src/lib/client/components/features/dashboard/checkpoint-action-bar.svelte
+++ b/webapp/src/lib/client/components/features/dashboard/checkpoint-action-bar.svelte
@@ -181,7 +181,7 @@
                 <Zap class="h-4 w-4 text-blue-600 fill-blue-600" />
 
                 {#if currentCheckpoint}
-                    <CopyButton truncate={true} maxLength={50}>{currentCheckpoint}</CopyButton>
+                    <CopyButton truncate={true} maxLength={50} value={currentCheckpoint} />
                 {:else}
                     <Badge variant="outline" class="bg-background text-muted-foreground border-border font-mono text-sm px-3 py-1">
                         No checkpoint available

--- a/webapp/src/lib/client/components/features/dashboard/checkpoint-token.ts
+++ b/webapp/src/lib/client/components/features/dashboard/checkpoint-token.ts
@@ -1,0 +1,90 @@
+/**
+ * Helpers for building LeoBus read-checkpoint "z-tokens" of the form
+ * `z/YYYY/MM/DD/HH/mm/ss/` (all fields UTC).
+ *
+ * Kept free of Svelte and @internationalized/date so it can be unit-tested in a
+ * plain node environment and reused by the checkpoint action bar.
+ */
+
+/** Sentinel token meaning "from the beginning of time". */
+export const BEGINNING_CHECKPOINT_TOKEN = 'z/';
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+export interface CheckpointTokenParts {
+    /** Full year, e.g. 2026. */
+    year: number;
+    /** Month 1-12. */
+    month: number;
+    /** Day of month 1-31. */
+    day: number;
+    hour: number;
+    minute: number;
+    second: number;
+}
+
+/** Build a `z/YYYY/MM/DD/HH/mm/ss/` token from explicit (UTC) parts. */
+export function buildCheckpointToken(parts: CheckpointTokenParts): string {
+    return (
+        `z/${parts.year}/${pad(parts.month)}/${pad(parts.day)}/` +
+        `${pad(parts.hour)}/${pad(parts.minute)}/${pad(parts.second)}/`
+    );
+}
+
+/** The current time as a checkpoint token (UTC). */
+export function nowCheckpointToken(date: Date = new Date()): string {
+    return buildCheckpointToken({
+        year: date.getUTCFullYear(),
+        month: date.getUTCMonth() + 1,
+        day: date.getUTCDate(),
+        hour: date.getUTCHours(),
+        minute: date.getUTCMinutes(),
+        second: date.getUTCSeconds(),
+    });
+}
+
+/**
+ * Parse an `<input type="time">` value (`HH:mm` or `HH:mm:ss`) into numeric parts.
+ * Seconds default to 0 when omitted. Returns null if the value is malformed or
+ * out of range.
+ */
+export function parseTimeInput(time: string): { hour: number; minute: number; second: number } | null {
+    const match = /^(\d{1,2}):(\d{2})(?::(\d{2}))?$/.exec(time.trim());
+    if (!match) return null;
+
+    const hour = Number(match[1]);
+    const minute = Number(match[2]);
+    const second = match[3] !== undefined ? Number(match[3]) : 0;
+
+    if (hour > 23 || minute > 59 || second > 59) return null;
+    return { hour, minute, second };
+}
+
+/** A calendar date's year / month (1-based) / day — matches @internationalized/date's CalendarDate. */
+export interface CalendarDateParts {
+    year: number;
+    month: number;
+    day: number;
+}
+
+/**
+ * Build a checkpoint token from a picked calendar date and a time string,
+ * interpreting both as UTC. Returns null when either input is missing/invalid so
+ * the caller can surface a validation error.
+ */
+export function checkpointTokenFromDateTime(
+    date: CalendarDateParts | null | undefined,
+    time: string,
+): string | null {
+    if (!date) return null;
+    const parsed = parseTimeInput(time);
+    if (!parsed) return null;
+    return buildCheckpointToken({
+        year: date.year,
+        month: date.month,
+        day: date.day,
+        hour: parsed.hour,
+        minute: parsed.minute,
+        second: parsed.second,
+    });
+}

--- a/webapp/src/lib/server/services/bus-data.ts
+++ b/webapp/src/lib/server/services/bus-data.ts
@@ -1,0 +1,138 @@
+/**
+ * bus-data — the SINGLE seam between the SvelteKit API routes and the bus data layer.
+ *
+ * Every API route imports its data functions from HERE (not from dynamoService directly).
+ * At runtime this delegates to the real DynamoDB-backed dynamoService, unless the dev-only
+ * mock bus is active, in which case it delegates to the in-memory mock-dynamo-service.
+ *
+ * PROD-EXCLUSION GUARANTEE
+ * ------------------------
+ * `dev` comes from `$app/environment`, which SvelteKit statically inlines to `false` in a
+ * production build. `useMock` therefore folds to `false` at build time, the mock branch
+ * becomes dead code, and the dynamic `import('./mock/...')` is never reachable — so the mock
+ * data-service can NEVER activate in a deployed build, regardless of the MOCK_BUS env var.
+ * The mock is only ever pulled in via `vite dev` with `MOCK_BUS=1` (see `npm run dev:mock`).
+ */
+import { dev } from '$app/environment';
+import { env } from '$env/dynamic/private';
+import type { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import * as real from './dynamoService';
+import type { ScanOpts } from './dynamoService';
+import type {
+  AwsCreds,
+  BotSettings,
+  DashboardStats,
+  DashboardStatsRequest,
+  MergedStatsRecord,
+  QueueSettings,
+  StatsQueryRequest,
+  SystemSettings,
+} from '$lib/types';
+import type { DashboardSettings } from '$lib/client/components/features/dashboard/types';
+
+const useMock = dev && env.MOCK_BUS === '1';
+
+type MockModule = typeof import('./mock/mock-dynamo-service');
+let mockPromise: Promise<MockModule> | null = null;
+/** Load the mock module lazily and only when the dev gate is open (keeps it out of prod). */
+function loadMock(): Promise<MockModule> {
+  if (!mockPromise) mockPromise = import('./mock/mock-dynamo-service');
+  return mockPromise;
+}
+
+export async function getRelationShips(creds: AwsCreds): Promise<BotSettings[]> {
+  if (useMock) return (await loadMock()).getRelationShips(creds);
+  return real.getRelationShips(creds);
+}
+
+export async function scanLeoEventQueues(creds: AwsCreds): Promise<QueueSettings[]> {
+  if (useMock) return (await loadMock()).scanLeoEventQueues(creds);
+  return real.scanLeoEventQueues(creds);
+}
+
+export async function scanLeoSystems(creds: AwsCreds): Promise<SystemSettings[]> {
+  if (useMock) return (await loadMock()).scanLeoSystems(creds);
+  return real.scanLeoSystems(creds);
+}
+
+export async function getStats(
+  creds: AwsCreds,
+  params: StatsQueryRequest,
+): Promise<MergedStatsRecord[]> {
+  if (useMock) return (await loadMock()).getStats(creds, params);
+  return real.getStats(creds, params);
+}
+
+export async function getDashboardStats(
+  creds: AwsCreds,
+  params: DashboardStatsRequest,
+): Promise<DashboardStats> {
+  if (useMock) return (await loadMock()).getDashboardStats(creds, params);
+  return real.getDashboardStats(creds, params);
+}
+
+export async function getQueueDashboardStats(
+  creds: AwsCreds,
+  params: DashboardStatsRequest,
+): ReturnType<typeof real.getQueueDashboardStats> {
+  if (useMock) return (await loadMock()).getQueueDashboardStats(creds, params);
+  return real.getQueueDashboardStats(creds, params);
+}
+
+export async function getSettings(creds: AwsCreds, id: string): Promise<DashboardSettings> {
+  if (useMock) return (await loadMock()).getSettings(creds, id);
+  return real.getSettings(creds, id);
+}
+
+export async function saveBotSettings(
+  creds: AwsCreds,
+  id: string,
+  updates: Record<string, any>,
+): Promise<void> {
+  if (useMock) return (await loadMock()).saveBotSettings(creds, id, updates);
+  return real.saveBotSettings(creds, id, updates);
+}
+
+export async function saveQueueSettings(
+  creds: AwsCreds,
+  id: string,
+  updates: Record<string, any>,
+): Promise<void> {
+  if (useMock) return (await loadMock()).saveQueueSettings(creds, id, updates);
+  return real.saveQueueSettings(creds, id, updates);
+}
+
+export async function saveSystemSettings(
+  creds: AwsCreds,
+  id: string,
+  updates: Record<string, any>,
+): Promise<void> {
+  if (useMock) return (await loadMock()).saveSystemSettings(creds, id, updates);
+  return real.saveSystemSettings(creds, id, updates);
+}
+
+export async function saveCron(
+  creds: AwsCreds,
+  params: {
+    id: string;
+    executeNow?: boolean;
+    executeNowClear?: boolean;
+    checkpoint?: Record<string, string>;
+  },
+): Promise<void> {
+  if (useMock) return (await loadMock()).saveCron(creds, params);
+  return real.saveCron(creds, params);
+}
+
+/**
+ * Generic table scan used by the /api/resources search route. Under the mock bus it returns
+ * an empty result (no AWS); otherwise it delegates to the real parallel scan.
+ */
+export async function parallelScan<T>(
+  client: DynamoDBClient,
+  opts: ScanOpts,
+  segments: number,
+): Promise<T[]> {
+  if (useMock) return (await loadMock()).parallelScan<T>(client, opts, segments);
+  return real.parallelScan<T>(client, opts, segments);
+}

--- a/webapp/src/lib/server/services/dynamoService.ts
+++ b/webapp/src/lib/server/services/dynamoService.ts
@@ -536,7 +536,12 @@ async function getBotState(creds: AwsCreds, id: string): Promise<BotSettings> {
     const docClient = DynamoDBDocumentClient.from(client);
     const command = new GetCommand({
         TableName: LEO_CRON_TABLE(),
-        Key: { id: id.replace(/^bot:/, "") }
+        Key: { id: id.replace(/^bot:/, "") },
+        // Strongly consistent read: saveCron/saveBotSettings write with PutCommand and the
+        // UI re-reads settings immediately after. A default (eventually-consistent) read can
+        // race the write and return the old checkpoint, so the header shows a stale value
+        // even though the just-saved change took effect (ES-3461).
+        ConsistentRead: true,
     });
     const response = await docClient.send(command);
 

--- a/webapp/src/lib/server/services/mock/mock-dynamo-service.ts
+++ b/webapp/src/lib/server/services/mock/mock-dynamo-service.ts
@@ -1,0 +1,193 @@
+/**
+ * mock-dynamo-service — a drop-in, in-memory replacement for dynamoService (ES-3461).
+ *
+ * Exposes the SAME function names the SvelteKit API routes import, backed by the committed
+ * mock-bots fixture plus a module-level in-memory store. The store makes read-after-write
+ * work (ES-3461 issue 2): saveCron / saveBotSettings mutate it, and the next getSettings /
+ * getRelationShips reflects the change — exactly like the real ConsistentRead path, but with
+ * no AWS.
+ *
+ * Every function takes the same `creds` first argument as dynamoService and ignores it.
+ * This module is only ever loaded through `bus-data.ts` behind the `dev && MOCK_BUS=1` gate,
+ * so it never ships in a production bundle.
+ */
+import type {
+  AwsCreds,
+  BotSettings,
+  DashboardStats,
+  DashboardStatsRequest,
+  MergedStatsRecord,
+  QueueSettings,
+  StatsQueryRequest,
+  SystemSettings,
+} from '$lib/types';
+import type { DashboardSettings } from '$lib/client/components/features/dashboard/types';
+import type * as Real from '../dynamoService';
+import { MOCK_BOTS, makeMockBot, mockStatsFor } from '$lib/testing/mock-bots';
+
+// ---------------------------------------------------------------------------
+// In-memory stores (survive for the lifetime of the dev server process).
+// Seeded from the fixture; mutated by the save* functions.
+// ---------------------------------------------------------------------------
+const botStore = new Map<string, BotSettings>();
+for (const bot of MOCK_BOTS) botStore.set(bot.id, structuredClone(bot));
+
+const queueStore = new Map<string, QueueSettings>();
+const systemStore = new Map<string, SystemSettings>();
+
+/** Strip a bot:/queue:/system: type prefix to get the raw store key. */
+function rawId(id: string): string {
+  return id.replace(/^(bot|queue|system):/, '');
+}
+
+function emptyCompareValue() {
+  return { prev: 0, current: 0, change: '0%' };
+}
+
+/** A minimal, valid, empty DashboardStats — enough for the dashboard to render nothing. */
+function emptyDashboardStats(): DashboardStats {
+  return {
+    executions: [],
+    errors: [],
+    duration: [],
+    queues: { read: {}, write: {} },
+    compare: {
+      executions: emptyCompareValue(),
+      errors: emptyCompareValue(),
+      duration: emptyCompareValue(),
+    },
+    start: 0,
+    end: 0,
+    buckets: [],
+  };
+}
+
+export async function getRelationShips(_creds: AwsCreds): Promise<BotSettings[]> {
+  return structuredClone([...botStore.values()]);
+}
+
+export async function scanLeoEventQueues(_creds: AwsCreds): Promise<QueueSettings[]> {
+  return structuredClone([...queueStore.values()]);
+}
+
+export async function scanLeoSystems(_creds: AwsCreds): Promise<SystemSettings[]> {
+  return structuredClone([...systemStore.values()]);
+}
+
+export async function getStats(
+  _creds: AwsCreds,
+  params: StatsQueryRequest,
+): Promise<MergedStatsRecord[]> {
+  const out: MergedStatsRecord[] = [];
+  for (const nodeId of params.nodeIds ?? []) {
+    const stats = mockStatsFor(rawId(nodeId));
+    if (stats) out.push({ ...structuredClone(stats), id: nodeId });
+  }
+  return out;
+}
+
+export async function getDashboardStats(
+  _creds: AwsCreds,
+  _params: DashboardStatsRequest,
+): Promise<DashboardStats> {
+  return emptyDashboardStats();
+}
+
+// Return type mirrors the real (inferred) queue-dashboard shape so the seam stays typed.
+type QueueDashboardStats = Awaited<ReturnType<typeof Real.getQueueDashboardStats>>;
+export async function getQueueDashboardStats(
+  _creds: AwsCreds,
+  _params: DashboardStatsRequest,
+): Promise<QueueDashboardStats> {
+  return emptyDashboardStats() as unknown as QueueDashboardStats;
+}
+
+export async function getSettings(_creds: AwsCreds, id: string): Promise<DashboardSettings> {
+  const raw = rawId(id);
+  if (id.startsWith('queue:')) {
+    return (queueStore.get(raw) ?? { event: raw }) as DashboardSettings;
+  }
+  if (id.startsWith('system:')) {
+    return (systemStore.get(raw) ?? { id: raw }) as DashboardSettings;
+  }
+  const bot = botStore.get(raw) ?? makeMockBot({ id: raw });
+  return structuredClone(bot) as DashboardSettings;
+}
+
+export async function saveBotSettings(
+  _creds: AwsCreds,
+  id: string,
+  updates: Record<string, any>,
+): Promise<void> {
+  const raw = rawId(id);
+  const bot = botStore.get(raw) ?? makeMockBot({ id: raw });
+  const merged: BotSettings = { ...bot, ...updates };
+  if (updates.health) merged.health = { ...(bot.health ?? {}), ...updates.health };
+  botStore.set(raw, merged);
+}
+
+export async function saveQueueSettings(
+  _creds: AwsCreds,
+  id: string,
+  updates: Record<string, any>,
+): Promise<void> {
+  const raw = rawId(id);
+  const existing = queueStore.get(raw) ?? ({ event: raw } as QueueSettings);
+  queueStore.set(raw, { ...existing, ...updates, event: raw });
+}
+
+export async function saveSystemSettings(
+  _creds: AwsCreds,
+  id: string,
+  updates: Record<string, any>,
+): Promise<void> {
+  const raw = rawId(id);
+  const existing = systemStore.get(raw) ?? ({ id: raw } as SystemSettings);
+  systemStore.set(raw, { ...existing, ...updates, id: raw });
+}
+
+export async function saveCron(
+  _creds: AwsCreds,
+  params: {
+    id: string;
+    executeNow?: boolean;
+    executeNowClear?: boolean;
+    checkpoint?: Record<string, string>;
+  },
+): Promise<void> {
+  const raw = rawId(params.id);
+  const bot = botStore.get(raw) ?? makeMockBot({ id: raw });
+  const updated = structuredClone(bot);
+
+  if (params.executeNow) {
+    updated.trigger = Date.now();
+    updated.errorCount = 0;
+  }
+
+  // Write the checkpoint into the store so the next getSettings/getRelationShips shows it
+  // immediately — the read-after-write guarantee the real path gets via ConsistentRead.
+  if (params.checkpoint) {
+    updated.checkpoints = updated.checkpoints ?? { read: {}, write: {} };
+    updated.checkpoints.read = updated.checkpoints.read ?? {};
+    for (const [queueId, checkpointValue] of Object.entries(params.checkpoint)) {
+      updated.checkpoints.read[queueId] = {
+        ...(updated.checkpoints.read[queueId] ?? {}),
+        checkpoint: checkpointValue,
+      };
+    }
+  }
+
+  botStore.set(raw, updated);
+}
+
+/**
+ * Generic table scan used by the /api/resources search route. The mock has no tables to
+ * scan, so it returns an empty result — search is simply empty under the mock bus.
+ */
+export async function parallelScan<T>(
+  _client: unknown,
+  _opts: unknown,
+  _segments: number,
+): Promise<T[]> {
+  return [] as T[];
+}

--- a/webapp/src/lib/testing/README.md
+++ b/webapp/src/lib/testing/README.md
@@ -1,0 +1,63 @@
+# Botmon test infrastructure (ES-3461)
+
+Committed, injectable test data for botmon UI states — the permanent replacement for the
+throwaway "mock bus" harness that ES-3461 was originally verified with.
+
+## What's here
+
+- **`mock-bots.ts`** — framework-free fixture (no svelte/browser imports). Named preset
+  factories, one per UI state:
+
+  | Preset | Status | Needs stats? |
+  |--------|--------|--------------|
+  | `mockHealthy` | running | no |
+  | `mockRogue` | rogue (errorCount 25) | no |
+  | `mockRoguePaused` | rogue (rogue wins over paused) | no |
+  | `mockPaused` | paused | no |
+  | `mockArchivedRogue` | archived (archived wins over rogue) | no |
+  | `mockBlocked` | blocked (current-window errors) | yes → `makeErrorStats` |
+  | `mockDanger` | danger (source-lag alarm) | yes → `makeAlarmStats` |
+  | `mockCheckpoint` | running, carries a real z-token | no |
+
+  `MOCK_BOTS` is the home-catalog fixture (6 bots, matching
+  `research/ES-3461/playground-verify/01-catalog.png`). `MOCK_STATS_BY_ID` / `mockStatsFor(id)`
+  return stats only for the presets that need them — every other preset hits the no-stats path
+  (`getStats → []`), which is the exact case the ES-3461 status fix addressed.
+
+- **`story-appstate.svelte`** — supplies a no-op `appState` context so the name-cell component
+  mounts inside Storybook.
+
+## Where the fixture is used
+
+1. **Node logic test** —
+   `tests/lib/client/components/features/bot/bot-status.presets.test.ts` pins every preset
+   against `evaluateBotStatus`, including a "no-stats path" block for the ES-3461 gap.
+   Run: `npx vitest run tests/lib/client/components/features/bot/bot-status.presets.test.ts --environment node`
+2. **Storybook state stories** —
+   `src/lib/client/components/features/bot-table/bot-table-name-cell.stories.svelte` renders one
+   story per preset and asserts the status ring in a `play` function (run as browser tests by the
+   Storybook vitest project). Run: `npm test`.
+3. **Whole-app dev without AWS** — `npm run dev:mock` (see below).
+
+## Running the whole app without AWS
+
+```
+npm run dev:mock
+```
+
+This sets `MOCK_BUS=1` (plus dummy AWS/auth env vars) and starts `vite dev`. The single seam
+`src/lib/server/services/bus-data.ts` then routes every API call to
+`src/lib/server/services/mock/mock-dynamo-service.ts` instead of DynamoDB. The mock keeps an
+in-memory store so settings/checkpoint saves read back immediately (ES-3461 issue 2).
+
+**The mock only works under `vite dev`.** `bus-data.ts` gates it on `dev` from
+`$app/environment`, which is statically `false` in a production build, so the mock branch is
+dead-code-eliminated and can never activate in a deployed build — regardless of `MOCK_BUS`.
+
+## Adding a new state
+
+1. Add a preset factory (and, if it needs stats to reach its status, a `MOCK_STATS_BY_ID`
+   entry) in `mock-bots.ts`.
+2. Add an assertion for it in `bot-status.presets.test.ts`.
+3. Add a `<Story>` for it in `bot-table-name-cell.stories.svelte`.
+4. If it belongs in the home catalog, add it to `MOCK_BOTS`.

--- a/webapp/src/lib/testing/README.md
+++ b/webapp/src/lib/testing/README.md
@@ -46,9 +46,17 @@ npm run dev:mock
 ```
 
 This sets `MOCK_BUS=1` (plus dummy AWS/auth env vars) and starts `vite dev`. The single seam
-`src/lib/server/services/bus-data.ts` then routes every API call to
+`src/lib/server/services/bus-data.ts` then routes the DynamoDB-backed API calls to
 `src/lib/server/services/mock/mock-dynamo-service.ts` instead of DynamoDB. The mock keeps an
 in-memory store so settings/checkpoint saves read back immediately (ES-3461 issue 2).
+
+**What mock mode does not cover.** The seam sits in front of `dynamoService` only, so the six
+routes that read the cron/event/stats tables are mocked: `api/resources`, `api/cron/save`,
+`api/dashboard/details`, `api/dashboard/settings`, `api/workflow/relationships`,
+`api/workflow/stats`. Routes that bypass `dynamoService` still need real AWS: `api/eventTrace`
+and `api/queue/event-search` read RStreams directly (event payloads, trace, queue search), and
+`api/dashboard/schema` reads S3 through `schemaService`. Expect those pages to error under
+`dev:mock`.
 
 **The mock only works under `vite dev`.** `bus-data.ts` gates it on `dev` from
 `$app/environment`, which is statically `false` in a production build, so the mock branch is

--- a/webapp/src/lib/testing/copy-button-harness.svelte
+++ b/webapp/src/lib/testing/copy-button-harness.svelte
@@ -1,0 +1,28 @@
+<!--
+  Test-only harness for copy-button.svelte (ES-3461).
+
+  CopyButton is rendered with a value that changes after mount, which is exactly what the
+  dashboard header does when a checkpoint is saved. The button swaps the value so a story's
+  `play` function can assert that the displayed text follows it.
+-->
+<script lang="ts">
+    import CopyButton from '$comps/copy-button.svelte';
+
+    type HarnessProps = {
+        /** Value rendered on mount. */
+        first: string;
+        /** Value swapped in when the button is clicked. */
+        second: string;
+        truncate?: boolean;
+        maxLength?: number;
+    };
+
+    let { first, second, truncate = false, maxLength = 30 }: HarnessProps = $props();
+
+    let value = $state(first);
+</script>
+
+<div>
+    <button data-testid="swap" onclick={() => (value = second)}>swap</button>
+    <CopyButton {truncate} {maxLength} {value} />
+</div>

--- a/webapp/src/lib/testing/mock-bots.ts
+++ b/webapp/src/lib/testing/mock-bots.ts
@@ -1,0 +1,178 @@
+/**
+ * mock-bots — the canonical, injectable botmon test fixture (ES-3461).
+ *
+ * During ES-3461 we discovered several botmon status bugs (rogue detection, the no-stats
+ * short-circuit, stale checkpoints after save) that only a live "mock bus" harness surfaced.
+ * That harness used to be ad-hoc and was thrown away. This module is the PERMANENT
+ * reconstruction: a small set of deterministic bot/stats fixtures that describe every UI
+ * state we care about, in one place, fully typed against `$lib/types`.
+ *
+ * It is framework-free on purpose — NO svelte/browser imports — so it can be imported from:
+ *   - the server mock data-service (`$lib/server/services/mock/mock-dynamo-service`) that
+ *     backs `npm run dev:mock`,
+ *   - the node-environment logic test (`tests/.../bot-status.presets.test.ts`),
+ *   - the Storybook state stories (`bot-table-name-cell.stories.svelte`).
+ *
+ * To add a new state: add a preset factory + (if it needs stats) an entry in
+ * MOCK_STATS_BY_ID, then add it to a story and, if it belongs in the home catalog, to
+ * MOCK_BOTS. See `src/lib/testing/README.md`.
+ */
+import type {
+  BotSettings,
+  Checkpoints,
+  MergedStatsRecord,
+  ReadWriteStats,
+} from '$lib/types';
+
+/** A real z-token, shaped exactly like a live Leo checkpoint, for the checkpoint picker. */
+export const MOCK_CHECKPOINT_TOKEN = 'z/2026/07/09/08/07/00/';
+
+/** Queue id the mock bots read from — used as the key in stats/checkpoint records. */
+export const MOCK_SOURCE_QUEUE = 'queue:mock-source';
+
+const MINUTE = 60 * 1000;
+
+/**
+ * Build a fully-typed mock bot. `id` defaults to "mock-bot"; name/lambdaName derive from
+ * the id unless overridden. Everything else defaults to a healthy, running bot.
+ */
+export function makeMockBot(overrides: Partial<BotSettings> = {}): BotSettings {
+  const id = overrides.id ?? 'mock-bot';
+  return {
+    id,
+    name: id,
+    tags: 'app:mock,workflow:verify',
+    errorCount: 0,
+    paused: false,
+    archived: false,
+    checkpoints: { read: {}, write: {} },
+    health: {},
+    lambdaName: `${id}-lambda`,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a merged stats record. Empty read/write by default (no errors, no lag). Pass a
+ * partial to override — see makeErrorStats / makeAlarmStats for the interesting shapes.
+ */
+export function makeMockStats(overrides: Partial<MergedStatsRecord> = {}): MergedStatsRecord {
+  return { id: 'mock-bot', read: {}, write: {}, ...overrides };
+}
+
+/** A single read-stat entry keyed at "now" so it contributes no lag by default. */
+function readStat(overrides: Partial<ReadWriteStats> = {}): ReadWriteStats {
+  const now = Date.now();
+  return {
+    checkpoint: MOCK_CHECKPOINT_TOKEN,
+    timestamp: now,
+    source_timestamp: now,
+    units: 1000,
+    errors: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * Stats that carry current-window errors but a LOW error-rate — drives BLOCKED
+ * (hasCurrentErrors) without tripping the error-rate alarm (which would escalate to danger).
+ */
+export function makeErrorStats(id: string, errors = 5, units = 1000): MergedStatsRecord {
+  return makeMockStats({
+    id,
+    read: { [MOCK_SOURCE_QUEUE]: readStat({ errors, units }) },
+  });
+}
+
+/**
+ * Stats with high source-lag (well past SOURCE_LAG_THRESHOLD ~2.5min) and zero errors —
+ * drives the source-lag alarm, which escalates a running bot to DANGER.
+ */
+export function makeAlarmStats(id: string): MergedStatsRecord {
+  const now = Date.now();
+  return makeMockStats({
+    id,
+    read: {
+      [MOCK_SOURCE_QUEUE]: readStat({
+        errors: 0,
+        // source event is 10 minutes old → source_lag ~10min >> 2.5min threshold
+        source_timestamp: now - 10 * MINUTE,
+        timestamp: now,
+      }),
+    },
+  });
+}
+
+/** Build a Checkpoints object with a read checkpoint token set for a queue. */
+export function makeMockCheckpoint(
+  token: string,
+  queue: string = MOCK_SOURCE_QUEUE,
+): Checkpoints {
+  return { read: { [queue]: { checkpoint: token } }, write: {} };
+}
+
+// ---------------------------------------------------------------------------
+// Named preset factories — one per UI state. Factories (not shared constants)
+// so tests/stories/the mock store each get their own mutable copy.
+// ---------------------------------------------------------------------------
+
+/** Running / healthy — no errors, no stats needed. */
+export const mockHealthy = (): BotSettings => makeMockBot({ id: 'mock-healthy' });
+
+/** Rogue — persisted errorCount over the threshold (10). Rogue even with NO stats. */
+export const mockRogue = (): BotSettings => makeMockBot({ id: 'mock-rogue', errorCount: 25 });
+
+/** Rogue wins over paused — a paused bot that went rogue still shows rogue. */
+export const mockRoguePaused = (): BotSettings =>
+  makeMockBot({ id: 'mock-rogue-paused', errorCount: 25, paused: true });
+
+/** Paused (non-rogue) — shows paused, no stats needed. */
+export const mockPaused = (): BotSettings => makeMockBot({ id: 'mock-paused', paused: true });
+
+/** Archived wins over rogue — shows archived, no stats needed. */
+export const mockArchivedRogue = (): BotSettings =>
+  makeMockBot({ id: 'mock-archived-rogue', archived: true, errorCount: 25 });
+
+/** Blocked — not rogue, but has current-window errors (needs makeErrorStats). */
+export const mockBlocked = (): BotSettings => makeMockBot({ id: 'mock-blocked', errorCount: 0 });
+
+/** Danger — not rogue, not blocked, but alarmed via source-lag (needs makeAlarmStats). */
+export const mockDanger = (): BotSettings => makeMockBot({ id: 'mock-danger', errorCount: 0 });
+
+/** Checkpoint — carries a real z-token so the checkpoint picker has something to show. */
+export const mockCheckpoint = (): BotSettings =>
+  makeMockBot({
+    id: 'mock-checkpoint',
+    name: 'mock-checkpoint (use me for the picker)',
+    checkpoints: makeMockCheckpoint(MOCK_CHECKPOINT_TOKEN),
+  });
+
+/**
+ * The home / catalog fixture, matching research/ES-3461/playground-verify/01-catalog.png:
+ * healthy, rogue, rogue-paused, paused, archived-rogue, checkpoint. These are the six bots
+ * that render in the catalog table; each hits the no-stats path (getStats → []) so the
+ * status derives from the record alone — the exact case the ES-3461 fix addressed.
+ */
+export const MOCK_BOTS: BotSettings[] = [
+  mockHealthy(),
+  mockRogue(),
+  mockRoguePaused(),
+  mockPaused(),
+  mockArchivedRogue(),
+  mockCheckpoint(),
+];
+
+/**
+ * Stats keyed by bot id. Only the states that REQUIRE stats to reach their status get an
+ * entry (blocked needs current errors; danger needs a lag alarm). Every other preset is
+ * intentionally absent so it exercises the no-stats path.
+ */
+export const MOCK_STATS_BY_ID: Record<string, MergedStatsRecord> = {
+  'mock-blocked': makeErrorStats('mock-blocked'),
+  'mock-danger': makeAlarmStats('mock-danger'),
+};
+
+/** Stats for a bot id, or undefined (→ the no-stats path) when none are seeded. */
+export function mockStatsFor(id: string): MergedStatsRecord | undefined {
+  return MOCK_STATS_BY_ID[id];
+}

--- a/webapp/src/lib/testing/story-appstate.svelte
+++ b/webapp/src/lib/testing/story-appstate.svelte
@@ -1,0 +1,21 @@
+<!--
+  story-appstate — minimal AppState context provider for Storybook.
+
+  bot-table-name-cell.svelte reads `getContext("appState")` and calls navigation methods on
+  click. Stories don't have the real AppState, so this harness supplies a no-op stub and
+  renders its children beneath it. Wrap state stories with this (via setTemplate) so the
+  component mounts without throwing.
+-->
+<script lang="ts">
+  import { setContext, type Snippet } from 'svelte';
+
+  let { children }: { children: Snippet } = $props();
+
+  // No-op stand-in for AppState — the name cell only calls these two methods on click.
+  setContext('appState', {
+    navigateToDashboardView() {},
+    navigateToRelationshipView() {},
+  });
+</script>
+
+{@render children()}

--- a/webapp/src/routes/api/cron/save/+server.ts
+++ b/webapp/src/routes/api/cron/save/+server.ts
@@ -1,7 +1,7 @@
 import { getSession } from '$lib/server/utils';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { saveCron } from '$lib/server/services/dynamoService';
+import { saveCron } from '$lib/server/services/bus-data';
 
 export const POST: RequestHandler = async ({ locals, request }) => {
     const session = await getSession(locals);

--- a/webapp/src/routes/api/dashboard/details/+server.ts
+++ b/webapp/src/routes/api/dashboard/details/+server.ts
@@ -1,4 +1,4 @@
-import { getDashboardStats, getQueueDashboardStats } from '$lib/server/services/dynamoService';
+import { getDashboardStats, getQueueDashboardStats } from '$lib/server/services/bus-data';
 import { getSession } from '$lib/server/utils';
 import type { DashboardStatsApiResponse, DashboardStatsRequest } from '$lib/types';
 import { json } from '@sveltejs/kit';

--- a/webapp/src/routes/api/dashboard/settings/+server.ts
+++ b/webapp/src/routes/api/dashboard/settings/+server.ts
@@ -2,7 +2,7 @@ import { getSession } from '$lib/server/utils';
 import type { GetSettingsRequest } from '$lib/types';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { getSettings, saveBotSettings, saveQueueSettings, saveSystemSettings } from '$lib/server/services/dynamoService';
+import { getSettings, saveBotSettings, saveQueueSettings, saveSystemSettings } from '$lib/server/services/bus-data';
 import { perf } from '$lib/server/perf';
 
 export const POST: RequestHandler = async ({locals, request}) => {

--- a/webapp/src/routes/api/resources/+server.ts
+++ b/webapp/src/routes/api/resources/+server.ts
@@ -5,7 +5,7 @@ import { type SystemSettings, type AwsCreds, type BotSettings, type QueueSetting
 import type { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import type { RequestHandler } from './$types';
 import * as async from 'async';
-import { parallelScan } from '$lib/server/services/dynamoService';
+import { parallelScan } from '$lib/server/services/bus-data';
 import { env } from '$env/dynamic/private';
 const LEO_CRON_TABLE = () => env.LEO_CRON_TABLE ?? process.env.LEO_CRON_TABLE ?? '';
 const LEO_EVENT_TABLE = () => env.LEO_EVENT_TABLE ?? process.env.LEO_EVENT_TABLE ?? '';

--- a/webapp/src/routes/api/workflow/relationships/+server.ts
+++ b/webapp/src/routes/api/workflow/relationships/+server.ts
@@ -2,7 +2,7 @@ import {
   getRelationShips,
   scanLeoEventQueues,
   scanLeoSystems,
-} from "$lib/server/services/dynamoService";
+} from "$lib/server/services/bus-data";
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 import { getSession } from "$lib/server/utils";

--- a/webapp/src/routes/api/workflow/stats/+server.ts
+++ b/webapp/src/routes/api/workflow/stats/+server.ts
@@ -1,4 +1,4 @@
-import { getStats } from "$lib/server/services/dynamoService";
+import { getStats } from "$lib/server/services/bus-data";
 import { getSession } from "$lib/server/utils";
 import type { StatsApiResponse, StatsQueryRequest } from "$lib/types";
 import { json, type RequestHandler } from "@sveltejs/kit";

--- a/webapp/tests/lib/client/components/features/bot/bot-status.presets.test.ts
+++ b/webapp/tests/lib/client/components/features/bot/bot-status.presets.test.ts
@@ -1,0 +1,88 @@
+/**
+ * bot-status.presets.test — pins evaluateBotStatus against the committed mock-bot presets.
+ *
+ * This is the logic half of the ES-3461 test infrastructure: every named preset in
+ * `$lib/testing/mock-bots` must evaluate to the status the UI (and the Storybook state
+ * stories) expect. If a preset and the status logic ever drift, this fails first — before
+ * anyone has to launch the mock bus by hand.
+ */
+import { describe, it, expect } from 'vitest';
+import { evaluateBotStatus } from '$comps/features/bot/bot-status.utils';
+import {
+  mockHealthy,
+  mockRogue,
+  mockRoguePaused,
+  mockPaused,
+  mockArchivedRogue,
+  mockBlocked,
+  mockDanger,
+  mockCheckpoint,
+  mockStatsFor,
+} from '$lib/testing/mock-bots';
+
+describe('mock-bot presets → evaluateBotStatus', () => {
+  it('mockHealthy → running, not rogue', () => {
+    const bot = mockHealthy();
+    const result = evaluateBotStatus(bot, mockStatsFor(bot.id));
+    expect(result.status).toBe('running');
+    expect(result.rogue).toBe(false);
+  });
+
+  it('mockBlocked + error stats → blocked', () => {
+    const bot = mockBlocked();
+    const stats = mockStatsFor(bot.id);
+    expect(stats).toBeDefined(); // blocked REQUIRES current-window errors
+    const result = evaluateBotStatus(bot, stats);
+    expect(result.status).toBe('blocked');
+    expect(result.rogue).toBe(false);
+  });
+
+  it('mockDanger + alarm stats → danger', () => {
+    const bot = mockDanger();
+    const stats = mockStatsFor(bot.id);
+    expect(stats).toBeDefined(); // danger REQUIRES a lag alarm
+    const result = evaluateBotStatus(bot, stats);
+    expect(result.status).toBe('danger');
+    expect(result.isAlarmed).toBe(true);
+    expect(result.rogue).toBe(false);
+  });
+
+  it('mockCheckpoint → running (carries a real checkpoint token)', () => {
+    const bot = mockCheckpoint();
+    const result = evaluateBotStatus(bot, mockStatsFor(bot.id));
+    expect(result.status).toBe('running');
+    expect(bot.checkpoints?.read?.['queue:mock-source']?.checkpoint).toBe('z/2026/07/09/08/07/00/');
+  });
+
+  // The ES-3461 gap: rogue/paused/archived must be derived from the record alone when the
+  // bot has NO stats in the window. The live playground was the only thing that caught the
+  // original short-circuit-to-running bug; this block pins it so it can't regress silently.
+  describe('no-stats path (stats = undefined) — the ES-3461 gap', () => {
+    it('mockRogue with no stats → rogue', () => {
+      const bot = mockRogue();
+      expect(mockStatsFor(bot.id)).toBeUndefined(); // intentionally no stats
+      const result = evaluateBotStatus(bot, undefined);
+      expect(result.status).toBe('rogue');
+      expect(result.rogue).toBe(true);
+    });
+
+    it('mockRoguePaused with no stats → rogue (rogue wins over paused)', () => {
+      const bot = mockRoguePaused();
+      const result = evaluateBotStatus(bot, undefined);
+      expect(result.status).toBe('rogue');
+      expect(result.rogue).toBe(true);
+    });
+
+    it('mockPaused with no stats → paused', () => {
+      const bot = mockPaused();
+      const result = evaluateBotStatus(bot, undefined);
+      expect(result.status).toBe('paused');
+    });
+
+    it('mockArchivedRogue with no stats → archived (archived wins over rogue)', () => {
+      const bot = mockArchivedRogue();
+      const result = evaluateBotStatus(bot, undefined);
+      expect(result.status).toBe('archived');
+    });
+  });
+});

--- a/webapp/tests/lib/client/components/features/bot/bot-status.utils.test.ts
+++ b/webapp/tests/lib/client/components/features/bot/bot-status.utils.test.ts
@@ -87,8 +87,34 @@ describe('evaluateBotStatus', () => {
             const result = evaluateBotStatus(bot({ errorCount: 0 }), statsWithReadErrors(0));
             expect(result.status).toBe('running');
         });
+    });
 
-        it('returns running defaults when there are no stats', () => {
+    // Regression for the bug the playground pass caught: a rogue bot with NO stats in the
+    // window used to short-circuit to 'running'. Rogue/paused/archived must be derived from
+    // the record even when there are no window stats.
+    describe('no-stats path derives status from the record', () => {
+        it('reports rogue from the persisted count when there are no stats', () => {
+            const result = evaluateBotStatus(bot({ errorCount: 25 }), undefined);
+            expect(result.rogue).toBe(true);
+            expect(result.status).toBe('rogue');
+        });
+
+        it('rogue wins over paused with no stats', () => {
+            const result = evaluateBotStatus(bot({ paused: true, errorCount: 25 }), undefined);
+            expect(result.status).toBe('rogue');
+        });
+
+        it('reports paused (not running) for a non-rogue paused bot with no stats', () => {
+            const result = evaluateBotStatus(bot({ paused: true, errorCount: 0 }), undefined);
+            expect(result.status).toBe('paused');
+        });
+
+        it('reports archived with no stats', () => {
+            const result = evaluateBotStatus(bot({ archived: true, errorCount: 25 }), undefined);
+            expect(result.status).toBe('archived');
+        });
+
+        it('reports running defaults for a healthy bot with no stats', () => {
             const result = evaluateBotStatus(bot({ errorCount: 0 }), undefined);
             expect(result.status).toBe('running');
             expect(result.rogue).toBe(false);

--- a/webapp/tests/lib/client/components/features/bot/bot-status.utils.test.ts
+++ b/webapp/tests/lib/client/components/features/bot/bot-status.utils.test.ts
@@ -5,7 +5,7 @@ import type { BotSettings, MergedStatsRecord, ReadWriteStats } from '$lib/types'
 
 const NOW = Date.now();
 
-/** Build a minimal read-stat with the given error count and enough units to keep the error RATE low. */
+/** Build a minimal read-stat with the given (window) error count and enough units to keep the rate low. */
 function readStat(errors: number, units = 1000): ReadWriteStats {
     return {
         checkpoint: 'z/2026/07/30/00/00/00/',
@@ -21,6 +21,7 @@ function bot(overrides: Partial<BotSettings> = {}): BotSettings {
     return { id: 'my-bot', archived: false, paused: false, ...overrides };
 }
 
+/** Stats with `errors` errors in the current window (drives BLOCKED, not ROGUE). */
 function statsWithReadErrors(errors: number, units = 1000): MergedStatsRecord {
     return { id: 'my-bot', read: { 'queue:source': readStat(errors, units) } } as MergedStatsRecord;
 }
@@ -28,49 +29,67 @@ function statsWithReadErrors(errors: number, units = 1000): MergedStatsRecord {
 describe('evaluateBotStatus', () => {
     const ROGUE = BOT_STATUS_DEFAULTS.ROGUE_ERROR_THRESHOLD; // 10
 
-    describe('rogue vs blocked precedence (ES-3461 issue 3)', () => {
-        it('reports rogue (not blocked) when error count exceeds the rogue threshold', () => {
-            const result = evaluateBotStatus(bot(), statsWithReadErrors(ROGUE + 1));
+    describe('rogue is driven by the persisted errorCount (matches legacy bus-ui)', () => {
+        it('reports rogue when the persisted errorCount exceeds the threshold', () => {
+            const result = evaluateBotStatus(bot({ errorCount: ROGUE + 1 }), statsWithReadErrors(0));
             expect(result.rogue).toBe(true);
-            // Regression: a rogue bot always has errors > 0, so the BLOCKED branch used to
-            // clobber status back to 'blocked'. Rogue must win.
             expect(result.status).toBe('rogue');
         });
 
-        it('still reports blocked when there are current errors but below the rogue threshold', () => {
-            const result = evaluateBotStatus(bot(), statsWithReadErrors(3));
+        it('stays rogue even when the current window has zero errors', () => {
+            // The whole point of using the persisted counter: a narrow/quiet time window
+            // must not clear a rogue bot.
+            const result = evaluateBotStatus(bot({ errorCount: 25 }), statsWithReadErrors(0));
+            expect(result.status).toBe('rogue');
+        });
+
+        it('is NOT rogue when only the window has many errors but the persisted count is low', () => {
+            // 15 window errors but persisted errorCount 0 → blocked (current errors), not rogue.
+            const result = evaluateBotStatus(bot({ errorCount: 0 }), statsWithReadErrors(15));
             expect(result.rogue).toBe(false);
             expect(result.status).toBe('blocked');
         });
+    });
 
-        it('reports rogue at a high error count regardless of a low error rate', () => {
-            // 50 errors out of 100k units → 0.05% error rate (well under the 50% alarm),
-            // but still far past the rogue threshold.
-            const result = evaluateBotStatus(bot(), statsWithReadErrors(50, 100_000));
+    describe('rogue vs blocked precedence (ES-3461 issue 3)', () => {
+        it('reports rogue (not blocked) when a rogue bot also has current window errors', () => {
+            // Regression: the BLOCKED branch used to clobber status back to 'blocked'.
+            const result = evaluateBotStatus(bot({ errorCount: ROGUE + 1 }), statsWithReadErrors(3));
             expect(result.status).toBe('rogue');
+        });
+
+        it('still reports blocked when there are current errors but the bot is not rogue', () => {
+            const result = evaluateBotStatus(bot({ errorCount: 0 }), statsWithReadErrors(3));
+            expect(result.status).toBe('blocked');
         });
     });
 
-    describe('non-error statuses are unaffected', () => {
-        it('reports running when there are no errors', () => {
-            const result = evaluateBotStatus(bot(), statsWithReadErrors(0));
-            expect(result.status).toBe('running');
-        });
-
-        it('paused overrides rogue', () => {
-            const result = evaluateBotStatus(bot({ paused: true }), statsWithReadErrors(ROGUE + 5));
-            expect(result.status).toBe('paused');
-            // rogue flag is still surfaced for downstream badges/tooltips
+    describe('manual-state precedence', () => {
+        it('rogue wins over paused (a paused bot that went rogue still shows rogue)', () => {
+            const result = evaluateBotStatus(bot({ paused: true, errorCount: ROGUE + 5 }), statsWithReadErrors(0));
+            expect(result.status).toBe('rogue');
             expect(result.rogue).toBe(true);
         });
 
+        it('paused wins when the bot is not rogue', () => {
+            const result = evaluateBotStatus(bot({ paused: true, errorCount: 0 }), statsWithReadErrors(0));
+            expect(result.status).toBe('paused');
+        });
+
         it('archived overrides rogue', () => {
-            const result = evaluateBotStatus(bot({ archived: true }), statsWithReadErrors(ROGUE + 5));
+            const result = evaluateBotStatus(bot({ archived: true, errorCount: ROGUE + 5 }), statsWithReadErrors(0));
             expect(result.status).toBe('archived');
+        });
+    });
+
+    describe('non-error statuses', () => {
+        it('reports running when there are no errors', () => {
+            const result = evaluateBotStatus(bot({ errorCount: 0 }), statsWithReadErrors(0));
+            expect(result.status).toBe('running');
         });
 
         it('returns running defaults when there are no stats', () => {
-            const result = evaluateBotStatus(bot(), undefined);
+            const result = evaluateBotStatus(bot({ errorCount: 0 }), undefined);
             expect(result.status).toBe('running');
             expect(result.rogue).toBe(false);
             expect(result.errorCount).toBe(0);

--- a/webapp/tests/lib/client/components/features/bot/bot-status.utils.test.ts
+++ b/webapp/tests/lib/client/components/features/bot/bot-status.utils.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateBotStatus } from '$comps/features/bot/bot-status.utils';
+import { BOT_STATUS_DEFAULTS } from '$comps/features/bot/bot-status.constants';
+import type { BotSettings, MergedStatsRecord, ReadWriteStats } from '$lib/types';
+
+const NOW = Date.now();
+
+/** Build a minimal read-stat with the given error count and enough units to keep the error RATE low. */
+function readStat(errors: number, units = 1000): ReadWriteStats {
+    return {
+        checkpoint: 'z/2026/07/30/00/00/00/',
+        // Keep timestamps at "now" so lag alarms don't fire and confound the status.
+        timestamp: NOW,
+        source_timestamp: NOW,
+        units,
+        errors,
+    };
+}
+
+function bot(overrides: Partial<BotSettings> = {}): BotSettings {
+    return { id: 'my-bot', archived: false, paused: false, ...overrides };
+}
+
+function statsWithReadErrors(errors: number, units = 1000): MergedStatsRecord {
+    return { id: 'my-bot', read: { 'queue:source': readStat(errors, units) } } as MergedStatsRecord;
+}
+
+describe('evaluateBotStatus', () => {
+    const ROGUE = BOT_STATUS_DEFAULTS.ROGUE_ERROR_THRESHOLD; // 10
+
+    describe('rogue vs blocked precedence (ES-3461 issue 3)', () => {
+        it('reports rogue (not blocked) when error count exceeds the rogue threshold', () => {
+            const result = evaluateBotStatus(bot(), statsWithReadErrors(ROGUE + 1));
+            expect(result.rogue).toBe(true);
+            // Regression: a rogue bot always has errors > 0, so the BLOCKED branch used to
+            // clobber status back to 'blocked'. Rogue must win.
+            expect(result.status).toBe('rogue');
+        });
+
+        it('still reports blocked when there are current errors but below the rogue threshold', () => {
+            const result = evaluateBotStatus(bot(), statsWithReadErrors(3));
+            expect(result.rogue).toBe(false);
+            expect(result.status).toBe('blocked');
+        });
+
+        it('reports rogue at a high error count regardless of a low error rate', () => {
+            // 50 errors out of 100k units → 0.05% error rate (well under the 50% alarm),
+            // but still far past the rogue threshold.
+            const result = evaluateBotStatus(bot(), statsWithReadErrors(50, 100_000));
+            expect(result.status).toBe('rogue');
+        });
+    });
+
+    describe('non-error statuses are unaffected', () => {
+        it('reports running when there are no errors', () => {
+            const result = evaluateBotStatus(bot(), statsWithReadErrors(0));
+            expect(result.status).toBe('running');
+        });
+
+        it('paused overrides rogue', () => {
+            const result = evaluateBotStatus(bot({ paused: true }), statsWithReadErrors(ROGUE + 5));
+            expect(result.status).toBe('paused');
+            // rogue flag is still surfaced for downstream badges/tooltips
+            expect(result.rogue).toBe(true);
+        });
+
+        it('archived overrides rogue', () => {
+            const result = evaluateBotStatus(bot({ archived: true }), statsWithReadErrors(ROGUE + 5));
+            expect(result.status).toBe('archived');
+        });
+
+        it('returns running defaults when there are no stats', () => {
+            const result = evaluateBotStatus(bot(), undefined);
+            expect(result.status).toBe('running');
+            expect(result.rogue).toBe(false);
+            expect(result.errorCount).toBe(0);
+        });
+    });
+});

--- a/webapp/tests/lib/client/components/features/dashboard/checkpoint-token.test.ts
+++ b/webapp/tests/lib/client/components/features/dashboard/checkpoint-token.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+    BEGINNING_CHECKPOINT_TOKEN,
+    buildCheckpointToken,
+    nowCheckpointToken,
+    parseTimeInput,
+    checkpointTokenFromDateTime,
+} from '$comps/features/dashboard/checkpoint-token';
+
+describe('checkpoint-token helpers', () => {
+    describe('buildCheckpointToken', () => {
+        it('zero-pads month/day/time to two digits', () => {
+            expect(
+                buildCheckpointToken({ year: 2026, month: 4, day: 7, hour: 3, minute: 5, second: 9 }),
+            ).toBe('z/2026/04/07/03/05/09/');
+        });
+
+        it('leaves already two-digit fields intact', () => {
+            expect(
+                buildCheckpointToken({ year: 2026, month: 12, day: 31, hour: 23, minute: 59, second: 45 }),
+            ).toBe('z/2026/12/31/23/59/45/');
+        });
+    });
+
+    describe('nowCheckpointToken', () => {
+        it('formats a fixed date as a UTC token', () => {
+            const d = new Date(Date.UTC(2026, 3, 14, 10, 30, 45)); // month is 0-based here
+            expect(nowCheckpointToken(d)).toBe('z/2026/04/14/10/30/45/');
+        });
+    });
+
+    describe('parseTimeInput', () => {
+        it('parses HH:mm:ss', () => {
+            expect(parseTimeInput('10:30:45')).toEqual({ hour: 10, minute: 30, second: 45 });
+        });
+
+        it('defaults seconds to 0 for HH:mm', () => {
+            expect(parseTimeInput('09:05')).toEqual({ hour: 9, minute: 5, second: 0 });
+        });
+
+        it('rejects out-of-range and malformed values', () => {
+            expect(parseTimeInput('24:00:00')).toBeNull();
+            expect(parseTimeInput('10:60')).toBeNull();
+            expect(parseTimeInput('10:30:60')).toBeNull();
+            expect(parseTimeInput('not-a-time')).toBeNull();
+            expect(parseTimeInput('')).toBeNull();
+        });
+    });
+
+    describe('checkpointTokenFromDateTime', () => {
+        it('combines a calendar date and time into a UTC token', () => {
+            expect(
+                checkpointTokenFromDateTime({ year: 2026, month: 4, day: 14 }, '10:30:45'),
+            ).toBe('z/2026/04/14/10/30/45/');
+        });
+
+        it('returns null when the date is missing', () => {
+            expect(checkpointTokenFromDateTime(null, '10:30:45')).toBeNull();
+        });
+
+        it('returns null when the time is invalid', () => {
+            expect(checkpointTokenFromDateTime({ year: 2026, month: 4, day: 14 }, 'bad')).toBeNull();
+        });
+    });
+
+    it('exposes the beginning-of-time sentinel', () => {
+        expect(BEGINNING_CHECKPOINT_TOKEN).toBe('z/');
+    });
+});


### PR DESCRIPTION
_Co-authored by Claude on 2026-08-17._

## Summary

Fixes three botmonAlpha defects, and commits the test infrastructure that verified them.

- **Checkpoint calendar picker** — the Change Checkpoint dialog now offers a UTC date+time picker that emits a valid `z/YYYY/MM/DD/HH/mm/ss/` token; pasting a raw z-token still works.
- **Stale checkpoint display** — the header reflects a just-saved checkpoint without a manual refresh. This needed **two** fixes, and the second was only found by deploying: a strongly-consistent DynamoDB read on the server, *and* a `CopyButton` that re-renders when its value changes (it was scraping its own text once on mount, so the header stayed frozen on the pre-save token no matter how fresh the data was). See AD-007.
- **Unreachable rogue status** — rogue was always clobbered to `blocked` and was computed from a window-summed error count. It now matches the legacy React bus-ui: persisted `errorCount > 10`, rogue-over-paused precedence, and evaluated before the no-stats short-circuit.
- **Test infrastructure** — the ad-hoc mock-bus harness used to verify the above is now committed and injectable: a framework-free bot fixture with 8 state presets, per-state browser stories, and a dev-only mock bus behind one seam so the whole app runs without AWS.

## Tier

**Tier:** 2

## Jira

- Brief: n/a — ES is a single-ticket board (Model C); the hypothesis and brief are inline on the codework ticket.
- Codework: https://chb.atlassian.net/browse/ES-3461

## Scope

One concern: the three botmonAlpha defects from ES-3461, plus the test infrastructure that proves them. The infrastructure is bundled deliberately (decision-log AD-005): it *is* the evidence for the rogue-status fix — the no-stats regression in `bot-status.presets.test.ts` was found by that harness, and without it the fix has no reachable test. No unrelated refactors.

**Base:** `master`. This branch was originally cut from `feat/ES-2951-sveltekit5-auth-parity` and has been rebased onto `master` (decision-log AD-006). Every file the rebased commits touch is byte-identical between the two branches, so the rebase carried one trivial conflict: the commit that widened `.storybook/main.js` to discover `*.stories.svelte` and register `addon-svelte-csf` was dropped, because master's `.storybook/main.ts` already does both. Nothing else changed.

That base swap was then audited rather than assumed, since a rebase that applies cleanly can still land on a base the fix was never verified against. Four things checked: `origin/master` is an ancestor of the branch head, with nothing behind it and the remote in sync; the pre-rebase and post-rebase patches are line-for-line identical once the dropped `.storybook/main.js` hunk is excluded, so no work was lost in the replay; the type-check and test baselines were re-measured on master instead of quoted from the old base; and the two bases were diffed across the files that *consume* this change rather than only the files it touches. That last one is the check that matters — the sole divergence in a surface this PR relies on is `bot-relationship-tree.svelte`, and it is a filter-button hover animation, so the manual rogue verification done on the old base still holds. The `dynamoService` seam is also complete on master: no route imports it directly.

## What changed

**Fixes**
- `bot-status.utils.ts` — `BLOCKED` becomes an `else if` so it no longer clobbers rogue; rogue is driven by the persisted cron-record `errorCount > 10` (matching `old_ui/lib/stats.js`) rather than window-summed errors, making it a sticky state independent of the viewed time range; rogue takes precedence over paused (matching `old_ui/stores/dataStore.js`), with archived still overriding; rogue is evaluated before the no-stats short-circuit.
- `bot.state.svelte.ts` — `evaluateBotStatuses` no longer overwrites the persisted `bot.errorCount`; the window count moved to `computedErrorCount` (mirroring `computedSourceLag`/`WriteLag`), so a stats-only refresh can't corrupt the rogue signal. Display is unchanged (`computedErrorCount ?? errorCount`).
- `dynamoService.ts` — `getBotState` uses `ConsistentRead: true` so the post-write settings re-read returns the just-saved checkpoint.
- `checkpoint-token.ts` (new) + `checkpoint-action-bar.svelte` — UTC token build/parse helper and a "Pick date & time" preset alongside the raw "Custom Value" paste field.
- `copy-button.svelte` — takes a reactive `value` prop instead of rendering a snippet into a hidden `<pre>` and scraping `textContent` out of it inside an `$effect` keyed on the snippet reference. That reference never changes, so the text was captured on mount and frozen for the component's life; the hidden element updated and the visible text did not. The `ConsistentRead` fix above was therefore invisible in the UI until a reload. One call site in the repo, updated with it (AD-007); the change also drops a `tick()` round-trip and an `$effect` that threw on empty content.

**Test infrastructure**
- `src/lib/testing/mock-bots.ts` — framework-free fixture: `makeMockBot`/`makeMockStats`/`makeMockCheckpoint`, 8 state presets, and a `MOCK_BOTS` catalog.
- `bot-status.presets.test.ts` — node test over all 8 presets, including a dedicated no-stats block (the ES-3461 gap).
- `bot-table-name-cell.stories.svelte` — one story per state, each `play` fn asserting the status ring in real chromium.
- `src/lib/server/services/bus-data.ts` — **the single seam**. Six API routes now import their data functions from here. The in-memory `mock-dynamo-service.ts` activates only when `dev && MOCK_BUS === '1'`, and is prod-excluded because `$app/environment`'s `dev` is statically `false` in production builds.
- `npm run dev:mock` + `src/lib/testing/README.md` for how to add a state.
- `.storybook/preview.ts` + `.storybook/vitest.setup.ts` (new) — **this also repairs the Storybook test project on master.** `vitest.workspace.ts` names `.storybook/vitest.setup.ts` as its setup file and that file does not exist on master (there are stray `vitest.setup.ts` and `preview.ts` at the webapp root instead), so today all four story suites die with `Failed to fetch dynamically imported module` and the pre-existing Button/Header/Page stories never run. Verified by moving both files aside on this branch: 4 suites fail, 0 tests; restored, 16/16 pass.

**Docs**
- `src/lib/testing/README.md` — corrected "routes every API call" to the six routes the seam actually fronts, and named the three that still need real AWS (`eventTrace` and `queue/event-search` read RStreams, `dashboard/schema` reads S3). The old wording would send someone into unexplained errors under `dev:mock`.
- `AGENTS.md` — the repo had nothing on the test layout beyond `npm test # Vitest`. Now documents the two Vitest projects, the browser project's Playwright and `.storybook` setup-file requirements, `--project botmon` to skip the browser, and why `preview.ts` carries the `__svelteCsf` workaround for the addon prerelease.

## Tests / Validation (Ran / Not Run)

All rows below were re-run on the rebased, master-based branch — not carried over from the pre-rebase runs.

| Env / Path | Ran? | Evidence or testable rationale |
|---|---|---|
| Unit (node) | ✅ | `npx vitest run --project botmon` — 134 passed / 10 files, incl. the 14 rogue-precedence, 10 token, and 8 preset tests. Master's baseline is 102 / 7 files, so this adds 32 tests |
| Component (real chromium) | ✅ | `npx vitest run --project storybook` — 19 passed: 8/8 `bot-table-name-cell` state stories asserting the status ring, plus 3 `copy-button` stories asserting the header text follows a value that changes after mount. Those 3 were **RED before the fix** — 2 failed with the mount-time token still on screen, which is the exact symptom seen on the deployed stage |
| Type check | ✅ | `npm run check` — 43 errors / 11 files against a master baseline of 44 / 12. Zero new error sites (compared site-by-site, not by count); the PR clears one pre-existing error at `bot-status.utils.ts:84`. The 2 in `dynamoService.ts` are pre-existing casts at lines 120/138, untouched by the `ConsistentRead` change |
| Production build | ✅ | `npm run build` clean; `grep -rl "MOCK_BUS\|mock-dynamo" .svelte-kit/output/` returns nothing — the mock is genuinely tree-shaken out of the prod bundle |
| Live PlaygroundBus (data/logic) | ✅ | Real `saveCron` + `getSettings`/`getBotState` round-trips a checkpoint and returns it on the immediately-following read (issue 2, server half); real `evaluateBotStatus` classifies the two naturally-rogue bots (now errorCount 25556 / 1867) as rogue with no window stats (issue 3). Worth stating plainly: this row passing is what made the frozen header look fixed — a server-side round-trip cannot see a client that never re-reads |
| Local UI, mocked data (Playwright) | ✅ | Picker builds a correct UTC z-token, header updates after save, catalog rings show rogue / rogue-over-paused / paused / healthy |
| Deployed test-playground | ✅ | Deployed this branch to `test-playground` and walked it on real data. **This is what caught the frozen header** — every other row was green. Rogue verified end to end: the catalog paints the red ring on `ebl-test-20230613-weather-loader` with the clean `weather-processor` ringless beside it, on a 15m window with zero throughput (the no-window-stats case that used to lose rogue entirely). Picker verified: 6:30 PM UTC produced `z/2026/08/17/18/30/00/` and the write landed. Header freshness re-check on the redeployed stage is the one row still open |
| Relationship-tree rogue icon | ✅ | Checked on the deployed stage: the rogue bot's node renders as a red-rimmed octagon carrying `bot-rogue.png`, which is visibly distinct from `bot-blocked.png` (a solid pink octagon), so rogue and blocked *are* tellable apart in the tree even though the catalog ring is red for both. Blocked was also unreachable in that view — it requires current-window errors and the window had none |

## Rollout

- **Feature flag:** no. The mock bus is gated on `dev && MOCK_BUS === '1'`, which is a dev-only switch, not a runtime flag.
- **Backwards compatible:** yes. No schema, API-shape, or persisted-data changes. `ConsistentRead` is a read-side option only.
- **Data migration:** no.
- **Rollback path:** revert the PR. The six route files changed only their import source (`bus-data` instead of the service directly), so a revert restores the previous direct imports with no other coupling.

## AI Usage

- **Tool(s):** Claude Opus 5 via Claude Code, 2026-07-30 → 2026-08-17.
- **Skills / sessions:** `worktree-for-task`, `ambiguity-and-decision-log`, `contract-first-workflow`, `pr-from-task`.
- **The moment AI changed the outcome:** the first rogue fix was wrong, and a side-by-side read of the legacy React `old_ui/` sources against the SvelteKit rewrite is what caught it. That comparison surfaced *two* silent behavioral divergences introduced by the rewrite — rogue computed from a window-summed error count instead of the persisted one (so the state flickered with the selected time range), and paused hiding rogue (inverted precedence). Neither was in the ticket; both would have shipped as "fixed." A later run against the live playground bus then exposed a third gap — rogue was evaluated *after* the no-stats short-circuit, so a bot with no window stats never reached the check — which produced the third fix commit and the no-stats regression test.
- **Where AI got it wrong:** the PR was first opened against `feat/ES-2951-sveltekit5-auth-parity` because that was the branch's recorded base, passed through without being questioned. A human caught it. See AD-006.
- **What only deploying caught:** issue 2 was reported fixed on the strength of a green server-side round-trip against the live bus and a mock UI pass. Both were true and both missed the defect, because the mock pass had confirmed the header *after a page reload* — the note recording it says so in as many words — and a reload is exactly what hides a client that never re-reads its own value. Deploying and clicking it is what produced the screenshot with the 2023 token still on screen. The lesson is in the evidence, not the code: a "verified" row whose method quietly differs from the user's path is worth less than it looks.
- **Second pass on the base-branch miss:** re-auditing the base swap is what turned up two things the first pass had asserted rather than measured — the type-check baseline was 44 on master, not 43, and the two `.storybook` files this PR adds are what make the Storybook suites run at all. Neither changes the fix; both were wrong in the evidence.

## Reviewers

- **L1 (right thing?):** @Detroitiron — self-review; confirm the rogue semantics match legacy bus-ui, and that bundling the test harness (AD-005) is the right call rather than a follow-up PR.
- **L2 (correct implementation?):** @Detroitiron — self-review; both passes applied, L1 before L2.

Prior PRs on this repo (#35, #41) carried no second human reviewer. Flagging that honestly rather than naming a reviewer who hasn't agreed to it — happy to add one on request.

## Checklist

- [x] Jira ticket linked above (single-ticket ES board; brief inline)
- [x] Brief written before code started; plan reviewed; brief re-edited where the plan revealed gaps
- [x] Tests present (and a testable rationale for each "not run" row)
- [x] AI usage section is substantive — names the moment AI changed the outcome
- [x] Per-repo CLAUDE.md / AGENTS.md — gap surfaced and fixed in this PR: `AGENTS.md` now documents the two Vitest projects and the Storybook browser-test requirements, and `src/lib/testing/README.md` documents the harness and the limits of `dev:mock`
- [x] One concern per PR
- [x] No local paths in the body
- [x] `feature/ES-3461-botmon-fixes` branch; `ES-3461 <description>` title; based on `master`
- [x] Code follows project style; L1 then L2 self-review complete

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operational bot status semantics and checkpoint read paths that operators rely on, but behavior is aligned to legacy bus-ui and covered by new unit and browser tests.
> 
> **Overview**
> Fixes three **ES-3461** botmon issues and lands the committed test harness that proves them.
> 
> **Checkpoint UX** — The change-checkpoint dialog adds a **Pick date & time** preset (UTC calendar + time input) backed by new `checkpoint-token` helpers; raw z-token paste remains. **`CopyButton`** now takes a reactive **`value`** prop instead of scraping snippet children, so the dashboard header shows a just-saved checkpoint without reload.
> 
> **Stale reads** — `getBotState` uses **consistent DynamoDB reads** so post-save settings re-fetch return the new checkpoint.
> 
> **Rogue / status** — Rogue follows legacy bus-ui: **persisted `errorCount > 10`**, evaluated before the no-stats short-circuit, with **rogue over paused** and **blocked** only when not rogue. Stats refresh stores window errors on **`computedErrorCount`** so it does not overwrite the persisted rogue signal.
> 
> **Dev & tests** — API routes import through **`bus-data`** with an optional **`dev:mock`** in-memory bus; **`mock-bots`** presets, node tests, and Storybook **`play`** stories cover status rings and copy-button updates. Storybook Vitest setup and **`AGENTS.md`** document the browser test project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e8e2ed79627a62775ff12556a9d9b65f8a7d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


